### PR TITLE
Added Injective v1.17.2 mainnet upgrade documentation

### DIFF
--- a/.gitbook/docs.json
+++ b/.gitbook/docs.json
@@ -1055,6 +1055,7 @@
                   "infra/validator-mainnet/index",
                   "infra/validator-mainnet/peggo",
                   "infra/validator-mainnet/canonical-chain-upgrade",
+                  "infra/validator-mainnet/canonical-chain-upgrade-1.17.2",
                   "infra/validator-mainnet/canonical-chain-upgrade-1.17.1",
                   "infra/validator-mainnet/canonical-chain-upgrade-1.17.0",
                   "infra/validator-mainnet/canonical-chain-upgrade-1.16.4",

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.17.2.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-1.17.2.mdx
@@ -1,0 +1,105 @@
+---
+title: Upgrade to v1.17.2
+---
+
+Thursday, December 18th, 2025
+
+Following [Proposal 603](https://injhub.com/proposal/603/) This indicates that the upgrade procedure should be performed on block number **146295000**
+
+* [Summary](#summary)
+* [Recovery](#recovery)
+* [Upgrade Procedure](#upgrade-procedure)
+* [Notes for Validators](#notes-for-validators)
+
+## Summary
+
+The Injective Chain will undergo a scheduled enhancement upgrade on **Thursday, December 18th, 2025, 14:00 UTC**.
+
+The following is a short summary of the upgrade steps:
+
+1. Vote and wait till the node panics at block height **146295000**.
+2. Backing up configs, data, and keys used for running the Injective Chain.
+3. Install the [1.17.2](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.17.2-1765930431) binaries.
+4. Start your node with the new injectived binary to fulfill the upgrade.
+
+Upgrade coordination and support for validators will be available on the `#validators` private channel of the [Injective Discord](https://discord.gg/injective).
+
+The network upgrade can take the following potential pathways:
+
+1. **Happy path**:\
+   Validators successfully upgrade the chain without purging the blockchain history, and all validators are up within 5-10 minutes of the upgrade.
+2. **Not-so-happy path**:\
+   Validators have trouble upgrading to the latest Canonical chain.
+3. **Abort path**:\
+   In the rare event that the team becomes aware of unnoticed critical issues, the Injective team will attempt to patch all the breaking states and provide another official binary within 36 hours.\
+   If the chain is not successfully resumed within 36 hours, the upgrade will be announced as aborted on the `#validators` channel in [Injective's Discord](https://discord.gg/injective), and validators will need to resume running the chain without any updates or changes.
+
+## Recovery
+
+Prior to exporting chain state, validators are encouraged to take a full data snapshot at the export height before proceeding. Snapshotting depends heavily on infrastructure, but generally this can be done by backing up the `.injectived` directory.
+
+It is critically important to backup the `.injectived/data/priv_validator_state.json` file after stopping your injectived process. This file is updated every block as your validator participates in a consensus rounds. It is a critical file needed to prevent double-signing, in case the upgrade fails and the previous chain needs to be restarted.
+
+In the event that the upgrade does not succeed, validators and operators must restore the snapshot and downgrade back to Injective Chain release [1.17.1](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.17.1-1764720946) and continue this earlier chain until next upgrade announcement.
+
+## Upgrade Procedure
+
+### Notes for Validators
+
+You must remove the wasm cache before upgrading to the new version:
+
+```shell
+rm -rf .injectived/wasm/wasm/cache/
+```
+
+### Steps
+
+1.  Verify you are currently running the correct version (`1.17.1`) of `injectived`:
+
+    ```bash
+    $ injectived version
+    Version v1.17.1 (99ae041)
+    Compiled at 20251202-2355 using Go go1.23.9 (amd64)
+    ```
+
+2.  Make a backup of your `.injectived` directory:
+
+    ```bash
+    cp -r ~/.injectived ./injectived-backup
+    ```
+
+3. Download and install the `injective-chain` release for `1.17.2`:
+
+    ```bash
+    wget https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.17.2-1765930431/linux-amd64.zip
+    unzip linux-amd64.zip
+    sudo mv injectived peggo /usr/bin
+    sudo mv libwasmvm.x86_64.so /usr/lib
+    ```
+
+4.  Verify you are currently running the correct version (`1.17.2`) of `injectived` after downloading the `1.17.2` release:
+
+    ```bash
+    $ injectived version
+    Version v1.17.2 (b2809ae)
+    Compiled at 20251217-0013 using Go go1.23.9 (amd64)
+    ```
+5.  Start `injectived`:
+
+    ```bash
+    injectived start
+    ```
+
+6.  Verify you are currently running the correct version (`1.17.2`) of `peggo` after downloading the `1.17.2` release:
+
+    ```bash
+    $ peggo version
+    Version v1.17.2 (b2809ae)
+    Compiled at 20251217-0013 using Go go1.23.9 (amd64)
+    ```
+
+7.  Start peggo:
+
+    ```bash
+    peggo orchestrator
+    ```


### PR DESCRIPTION
Created new documentation page for Injective Protocol v1.17.2 mainnet upgrade based on the official release information. Added the page to the validator mainnet navigation structure.

---

Created by Mintlify agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive v1.17.2 upgrade guide for validators: schedule and target block height, high-level summary, three upgrade pathways (happy, degraded, abort), step-by-step upgrade and verification procedures, recovery and rollback guidance, post-upgrade validation checks, and coordination/support notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->