### PR TITLE
Fix markdown table formatting in EVM equivalence page

### DIFF
--- a/.gitbook/developers-evm/evm-equivalence.mdx
+++ b/.gitbook/developers-evm/evm-equivalence.mdx
@@ -11,7 +11,15 @@ Native EVM on Injective supports the latest version of `geth`, ensuring that dev
 
 ## Gas Fee Estimates for Transactions
 
-<table data-full-width="false"><thead><tr><th width="131"> </th><th width="162">Gas Price Range</th><th width="121">Token Price</th><th width="234">Create ERC-4337 Account</th><th width="157">Simple Transfer</th><th>ERC-20 Transfer</th></tr></thead><tbody><tr><td>Ethereum¹</td><td>30.5 ± 10.6 gwei</td><td>$3000</td><td>$35.25 ± $12.25</td><td>$1.9215 ± $0.6678</td><td>$5.9475 ± $2.067</td></tr><tr><td>Polygon²</td><td>224 ± 108 gwei</td><td>$0.4</td><td>$0.0345 ± $0.0166</td><td>$0.0018 ± $0.0009</td><td>$0.0058 ± $0.0028</td></tr><tr><td>Optimism³</td><td>0.30 ± 0.15 gwei</td><td>$3000</td><td>$0.3467 ± $0.1733</td><td>$0.0189 ± $0.0094</td><td>$0.0585 ± $0.0292</td></tr><tr><td><p>Avalanche⁴</p><p><br /></p></td><td>36.4 ± 4.5 nAVAX</td><td>$28</td><td>$0.3926 ± $0.0485</td><td>$0.0214 ± $0.0026</td><td>$0.0662 ± $0.0081</td></tr><tr><td>BnB Smart Chain⁵</td><td>7.05 ± 0.53 gwei</td><td>$600</td><td>$1.6296 ± $0.1225</td><td>$0.0888 ± $0.0066</td><td>$0.2749 ± $0.0206</td></tr><tr><td>Sei⁶</td><td>0.02 usei</td><td>$0.40</td><td>$0.0030</td><td>$0.00017</td><td>$0.0005</td></tr><tr><td>Injective⁷</td><td>0.16 nINJ</td><td>$23</td><td>$0.0014</td><td>$0.00008</td><td>$0.0002</td></tr></tbody></table>
+| Chain | Gas Price Range | Token Price | Create ERC-4337 Account | Simple Transfer | ERC-20 Transfer |
+| --- | --- | --- | --- | --- | --- |
+| Ethereum¹ | 30.5 ± 10.6 gwei | $3000 | $35.25 ± $12.25 | $1.9215 ± $0.6678 | $5.9475 ± $2.067 |
+| Polygon² | 224 ± 108 gwei | $0.4 | $0.0345 ± $0.0166 | $0.0018 ± $0.0009 | $0.0058 ± $0.0028 |
+| Optimism³ | 0.30 ± 0.15 gwei | $3000 | $0.3467 ± $0.1733 | $0.0189 ± $0.0094 | $0.0585 ± $0.0292 |
+| Avalanche⁴ | 36.4 ± 4.5 nAVAX | $28 | $0.3926 ± $0.0485 | $0.0214 ± $0.0026 | $0.0662 ± $0.0081 |
+| BnB Smart Chain⁵ | 7.05 ± 0.53 gwei | $600 | $1.6296 ± $0.1225 | $0.0888 ± $0.0066 | $0.2749 ± $0.0206 |
+| Sei⁶ | 0.02 usei | $0.40 | $0.0030 | $0.00017 | $0.0005 |
+| Injective⁷ | 0.16 nINJ | $23 | $0.0014 | $0.00008 | $0.0002 |
 
 ### Note: Gas per Action <a href="#note-gas-per-action" id="note-gas-per-action"></a>
 


### PR DESCRIPTION
Converted HTML table to proper Markdown format to fix rendering issues where raw HTML tags were displaying in the table content.

Files changed:
- .gitbook/developers-evm/evm-equivalence.mdx

---

Created by Mintlify agent