### PR TITLE
Add Subaccounts section to DeFi Wallets Accounts page

### DIFF
--- a/.gitbook/defi/wallet/accounts.mdx
+++ b/.gitbook/defi/wallet/accounts.mdx
@@ -101,3 +101,21 @@ const buf3 = Buffer.from(publicKeyByte)
 const publicKey = Buffer.concat([buf1, buf2, buf3]).toString('base64')
 const type = '/injective.crypto.v1beta1.ethsecp256k1.PubKey'
 ```
+
+## Subaccounts
+
+Injective subaccounts allow a single main wallet address to manage multiple, isolated trading accounts. This is useful for power users, especially professional traders and market makers.
+
+<Tip>
+For technical implementation details on subaccounts, see the [Trading Account](/developers/concepts/trading-account) developer documentation.
+</Tip>
+
+### Key features and explanation
+
+- **Programmatic access**: This feature is designed to be highly accessible for programmatic trading via Injective's native APIs, catering to financial application developers.
+- **Advanced account management**: The subaccounts feature provides sophisticated account management capabilities, enabling users (e.g., institutions or algorithmic traders) to segregate funds and trading strategies within a single, primary Injective address.
+- **Isolation and organization**: Funds and orders within one subaccount are isolated from others, which is critical for managing risk, running different trading bots, or applying distinct strategies simultaneously without interference.
+- **Seamless transfers**: Users can easily transfer assets between their main account balance and their various subaccounts, as well as between different subaccounts, using specific messages on the Injective network.
+- **Integration with exchange modules**: The subaccounts functionality is part of Injective's core exchange module, which includes an on-chain order book and matching engine for spot, perpetual, futures, and options markets.
+
+Subaccounts function like separate, linked "portfolios" controlled by a single user account. This provides flexibility and operational control for participants in Injective's DeFi ecosystem.

--- a/.gitbook/developers/concepts/trading-account.mdx
+++ b/.gitbook/developers/concepts/trading-account.mdx
@@ -4,4 +4,8 @@ title: Trading Account
 
 Subaccounts or Trading Accounts are a concept that allows you to decouple the funds in the native Injective Bank module (which can be used for staking, bidding on auctions, participating in governance, creating markets, etc) into an isolated trading account from which you can execute trades. One Injective address can have an unlimited number of trading accounts. The way they are represented is `${ethereumAddress}${subaccountNonce}` where the `ethereumAddress` is the `hex` version of the `bech32` Injective address and the `subaccountNonce` is the nonce represented in 12 bytes. An example trading account at nonce 1 would be `0xc7dca7c15c364865f77a4fb67ab11dc95502e6fe000000000000000000000001`.
 
+<Tip>
+For a general overview of subaccounts and their key features, see the [Accounts](/defi/wallet/accounts#subaccounts) page.
+</Tip>
+
 Starting the v1.10.0 chain upgrade, the Bank balance and the default trading account (at nonce = 0) will be merged and the Bank funds will be directly used when executing trades originating from the default trading account.


### PR DESCRIPTION
Added a new "Subaccounts" section to the DeFi Wallets Accounts page explaining Injective subaccounts functionality. This section covers key features including programmatic access, advanced account management, isolation, transfers, and exchange module integration.

---

Created by Mintlify agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Subaccounts" section to wallet accounts docs describing isolated trading subaccounts under a single main address, with features like programmatic access, advanced management, isolation/organization, transfers, and exchange module integration.
  * Added a contextual tip in the trading-account docs linking to the Accounts page for more subaccounts details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->