### PR TITLE
Add Foundry configuration warning for Injective precompiles

### DIFF
--- a/.gitbook/developers-evm/evm-integrations-cheat-sheet.mdx
+++ b/.gitbook/developers-evm/evm-integrations-cheat-sheet.mdx
@@ -74,6 +74,14 @@ Guides:
 - Explorer: [`blockscout.injective.network`](https://blockscout.injective.network/)
 - Explorer API: [`blockscout-api.injective.network/api`](https://blockscout-api.injective.network/api)
 
+## Foundry
+
+Latest releases, with pre-built binaries for x86_64 Linux and macOS ARM64, can be found at [github.com/InjectiveLabs/foundry/releases](http://github.com/InjectiveLabs/foundry/releases).
+
+<Warning>
+In order to enable support for Injective precompiles on this forked version of Foundry, you must set `injective = true` inside config file `foundry.toml` or use an environment variable `FOUNDRY_INJECTIVE=true`.
+</Warning>
+
 ## Oracles
 
 - API3: 


### PR DESCRIPTION
Added a new Foundry section to the EVM Integrations Cheat Sheet with release information and a warning box explaining how to enable Injective precompiles support. This ensures developers know they must set `injective = true` in foundry.toml or use the FOUNDRY_INJECTIVE=true environment variable when using the Injective fork of Foundry.

Files changed:
- .gitbook/developers-evm/evm-integrations-cheat-sheet.mdx

---

Created by Mintlify agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Foundry integration guide with links to pre-built binaries and configuration instructions for enabling Injective precompiles support in development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->