### PR TITLE
Add Injective precompiles configuration warning to Foundry section

### DIFF
--- a/.gitbook/developers-evm/evm-integrations-faq.mdx
+++ b/.gitbook/developers-evm/evm-integrations-faq.mdx
@@ -66,6 +66,10 @@ you will need this so `forge`/ `cast` can do local simulations.
 Latest releases, with pre-built binaries for x86_64 Linux and macOS ARM64,
 can be found at [github.com/InjectiveLabs/foundry/releases](https://github.com/InjectiveLabs/foundry/releases).
 
+<Warning>
+In order to enable support for Injective precompiles on this forked version of Foundry, you must set `injective = true` inside config file `foundry.toml` or use an environment variable `FOUNDRY_INJECTIVE=true`.
+</Warning>
+
 ## Which EVM development infrastructure is available on Injective?
 
 Refer to the [EVM Integrations Cheat Sheet](/developers-evm/evm-integrations-cheat-sheet)


### PR DESCRIPTION
Added a warning box to the EVM integrations FAQ explaining that users must set `injective = true` in foundry.toml or use the FOUNDRY_INJECTIVE=true environment variable to enable Injective precompiles support. This critical configuration step was missing from the Foundry installation instructions.

Files changed:
- .gitbook/developers-evm/evm-integrations-faq.mdx

---

Created by Mintlify agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions in the EVM Integrations FAQ clarifying how to enable Injective precompiles through Foundry configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->