### PR TITLE
Fix double title on Binary Options Markets page

### DIFF
--- a/.gitbook/developers-native/injective/exchange/02_binary_options_markets.mdx
+++ b/.gitbook/developers-native/injective/exchange/02_binary_options_markets.mdx
@@ -3,8 +3,6 @@ sidebar_position: 2
 title: Binary Options Markets
 ---
 
-# Binary Options Markets
-
 ## Concept
 
 Binary options markets don't have base asset as other markets do, and they are quoted in **USDT** (there is a possibility other quote assets will be added later). Tickers for binary options markets usually follow the scheme of **UFC-KHABIB-TKO-09082022** or similar. Typically, binary options markets are used for betting on sport events, but can also be used for betting on any outcome. All markets have possible price bands between $0.00 and $1.00 with users able to put in orders from $0.01 to $0.99. ($0.00 and $1.00 respectively show an end condition that the outcome did not occur or did). The price submitted in the order is essentially an assumed probability of the given event (market) occurring.


### PR DESCRIPTION
Removed duplicate H1 heading from Binary Options Markets documentation page. The page title is already defined in the frontmatter, making the additional heading redundant.

---

Created by Mintlify agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Binary Options Markets documentation formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->