### PR TITLE
improve MTS page with clear distinction between erc20 module and bank precompile

### DIFF
--- a/.gitbook/developers-evm/multivm-token-standard.mdx
+++ b/.gitbook/developers-evm/multivm-token-standard.mdx
@@ -26,6 +26,7 @@ The system comprises two main components:
   * Developed in Go, this precompile is embedded directly in the Injective EVM.
   * It provides a Solidity interface that proxies ERC20 operations—such as mint, burn, and transfer—to the bank module.
 * [**ERC20 Module**](/developers-evm/erc20-module/):
+  * This module is a way to bring existing on-chain denoms into EVM world. The users who wish to create new MTS-based ERC20 tokens should use `Bank` precompile directly.
   * This module maps native bank denoms (e.g., INJ, IBC tokens, Peggy assets) to an ERC20 contract within the EVM.
   * It deploys MTS-compliant ERC20 contracts that always reflect the canonical token balance as maintained by the bank module.
 
@@ -33,11 +34,21 @@ The system comprises two main components:
 
 ### Creating an MTS-Compliant Token
 
+#### New ERC20 tokens ("erc20:..." denoms)
+
 1. [**Using Our Prebuilt Templates**](https://github.com/InjectiveLabs/solidity-contracts/tree/master/src):
    * Start with the provided Solidity templates, such as `BankERC20.sol`, `MintBurnBankERC20.sol`, or `FixedSupplyBankERC20.sol`.
 2. [**Deploying the Contract**](/developers-evm/smart-contracts/):
    * Deploy your MTS token contract on the Injective EVM network.
    * The contract automatically interacts with the Bank Precompile to update the canonical state.
+
+#### Existing Cosmos denoms (Tokenfactory, IBC, Peggy)
+
+1. Create a token pair inside erc20 module via `MsgCreateTokenPair`:
+  * Chain will upload EVM Smart Contract for you based on the existing denom configuration.
+2. Use custom ERC20 implementation for Smart Contract during pair creation (tokenfactory denoms only):
+  * Upload your custom ERC20 Smart Contract on chain first.
+  * Provide the address of the contract inside `MsgCreateTokenPair`.
 
 ### Interoperability and Cross-Chain Integration
 

--- a/.gitbook/developers-evm/multivm-token-standard.mdx
+++ b/.gitbook/developers-evm/multivm-token-standard.mdx
@@ -13,88 +13,99 @@ thereby enabling seamless interoperability and unified liquidity for decentraliz
 
 ## Why is MTS Important?
 
-* **Seamless Interoperability:** Tokens remain consistent across Cosmos and EVM environments.
-* **Unified Liquidity:** A single source of truth avoids liquidity fragmentation.
-* **Enhanced Developer Experience:** Standard tools like Hardhat, Foundry, and MetaMask work out of the box.
-* **Security & Efficiency:** All token state is maintained centrally in the bank module, ensuring robust security.
+- **Seamless Interoperability:** Tokens remain consistent across Cosmos and EVM environments.
+- **Unified Liquidity:** A single source of truth avoids liquidity fragmentation.
+- **Enhanced Developer Experience:** Standard tools like Hardhat, Foundry, and MetaMask work out of the box.
+- **Security & Efficiency:** All token state is maintained centrally in the bank module, ensuring robust security.
 
 ## Architecture
 
 The system comprises two main components:
 
-* [**Bank Precompile**](/developers-evm/bank-precompile/):
-  * Developed in Go, this precompile is embedded directly in the Injective EVM.
-  * It provides a Solidity interface that proxies ERC20 operations—such as mint, burn, and transfer—to the bank module.
-* [**ERC20 Module**](/developers-evm/erc20-module/):
-  * This module is a way to bring existing on-chain denoms into EVM world. The users who wish to create new MTS-based ERC20 tokens should use `Bank` precompile directly.
-  * This module maps native bank denoms (e.g., INJ, IBC tokens, Peggy assets) to an ERC20 contract within the EVM.
-  * It deploys MTS-compliant ERC20 contracts that always reflect the canonical token balance as maintained by the bank module.
+- [**Bank Precompile**](/developers-evm/bank-precompile/):
+  - Developed in Go, this precompile is embedded directly in the Injective EVM.
+  - It provides a Solidity interface that proxies ERC20 operations—such as mint, burn, and transfer—to the bank module.
+- [**ERC20 Module**](/developers-evm/erc20-module/):
+  - This module is used for representing existing on-chain denoms to EVM. Creating MTS-based ERC20 tokens should be thought the `Bank` precompile.
+  - This module maps native bank denoms (e.g., INJ, IBC tokens, Peggy assets) to an ERC20 contract within the EVM.
+  - It deploys MTS-compliant ERC20 contracts that always reflect the canonical token balance as maintained by the bank module.
 
-<figure><img src="/img/multivm-token-single-token-representation-architecture.png" alt="" /><figcaption><p>Single Token Representation Architecture</p></figcaption></figure>
+<figure>
+  <img
+    src="/img/multivm-token-single-token-representation-architecture.png"
+    alt=""
+  />
+  <figcaption>
+    <p>Single Token Representation Architecture</p>
+  </figcaption>
+</figure>
 
 ### Creating an MTS-Compliant Token
 
 #### New ERC20 tokens ("erc20:..." denoms)
 
 1. [**Using Our Prebuilt Templates**](https://github.com/InjectiveLabs/solidity-contracts/tree/master/src):
-   * Start with the provided Solidity templates, such as `BankERC20.sol`, `MintBurnBankERC20.sol`, or `FixedSupplyBankERC20.sol`.
+   - Start with the provided Solidity templates, such as `BankERC20.sol`, `MintBurnBankERC20.sol`, or `FixedSupplyBankERC20.sol`.
 2. [**Deploying the Contract**](/developers-evm/smart-contracts/):
-   * Deploy your MTS token contract on the Injective EVM network.
-   * The contract automatically interacts with the Bank Precompile to update the canonical state.
+   - Deploy your MTS token contract on the Injective EVM network.
+   - The contract automatically interacts with the Bank Precompile to update the canonical state.
 
-#### Existing Cosmos denoms (Tokenfactory, IBC, Peggy)
+#### Existing denoms (TokenFactory, IBC, Peggy)
 
-1. Create a token pair inside erc20 module via `MsgCreateTokenPair`:
-  * Chain will upload EVM Smart Contract for you based on the existing denom configuration.
+You have two options:
+
+1. Create a token pair inside erc20 module by submitting a `MsgCreateTokenPair` message.
+
 2. Use custom ERC20 implementation for Smart Contract during pair creation (tokenfactory denoms only):
-  * Upload your custom ERC20 Smart Contract on chain first.
-  * Provide the address of the contract inside `MsgCreateTokenPair`.
+
+- Upload your custom ERC20 Smart Contract on chain first.
+- Provide the address of the contract while submitting the `MsgCreateTokenPair` message.
 
 ### Interoperability and Cross-Chain Integration
 
-#### Native Interoperability*
+#### Native Interoperability\*
 
 Injective’s EVM is integrated directly into the Cosmos-based chain.
 
-* EVM smart contracts, when using MTS, perform operations that reflect immediately
+- EVM smart contracts, when using MTS, perform operations that reflect immediately
   on native modules (such as the exchange, staking, and governance modules).
-* [JSON-RPC endpoints](/developers-evm/network-information/)
+- [JSON-RPC endpoints](/developers-evm/network-information/)
   provided within the Injective binary are compatible with Ethereum,
   ensuring smooth developer integration.
 
 #### Cross-Chain Operations
 
-* **IBC Compatibility:** Existing native tokens
+- **IBC Compatibility:** Existing native tokens
   (e.g., those created via a
   [Token Factory](/developers-native/injective/tokenfactory/) or pegged via Peggy)
   are accessible from the EVM once an MTS pairing is established.
-* **Bridging Alternatives:** While many blockchains require separate bridge operations (lock, mint, unlock),
+- **Bridging Alternatives:** While many blockchains require separate bridge operations (lock, mint, unlock),
   MTS avoids these steps by natively synchronizing states.
 
 #### Allowances & Extended ERC20 Functions
 
-* MTS contracts maintain standard ERC20 functionalities such as allowances
+- MTS contracts maintain standard ERC20 functionalities such as allowances
   (approve/transferFrom).
-* Note that while the allowance mechanism is maintained within the EVM contract for convenience,
+- Note that while the allowance mechanism is maintained within the EVM contract for convenience,
   the ultimate balance is managed by the bank module, preserving integrity.
 
 ### Performance, Gas, and Security Considerations
 
 #### Gas Costs and Efficiency
 
-* Gas fees are paid in INJ.
-  While MTS operations via the EVM introduce an abstraction layer that may slightly increase gas usage compared to native transactions, 
+- Gas fees are paid in INJ.
+  While MTS operations via the EVM introduce an abstraction layer that may slightly increase gas usage compared to native transactions,
   the overall cost remains lower than comparable operations on Ethereum.
-* The gas model is designed to reflect a balance between EVM-style opcode costs and native module interactions.
+- The gas model is designed to reflect a balance between EVM-style opcode costs and native module interactions.
 
 #### Security
 
-* The [bank module](/developers-native/core/), as the single source of truth,
+- The [bank module](/developers-native/core/), as the single source of truth,
   underpins MTS’s security by ensuring that token balances are consistent and verifiable.
-* The use of [precompiles](/developers-evm/precompiles/) prevents common pitfalls
+- The use of [precompiles](/developers-evm/precompiles/) prevents common pitfalls
   like state desynchronization, ensuring that all operations -
   no matter where initiated—update the same canonical ledger.
-* Advanced security guidelines and best practices for smart contract development
+- Advanced security guidelines and best practices for smart contract development
   are provided in our security section and external resources.
 
 **ℹ️ Note:**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified ERC20 module role as representing existing on-chain denoms to the EVM.
  * Directs creators to use the Bank precompile for minting new MTS-based ERC20 tokens.
  * Split the token-creation guide into distinct flows for new ERC20 denoms vs existing Cosmos denoms.
  * Documented token-pair creation, including an option to register a custom ERC20 contract address for tokenfactory denoms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->