### PR TITLE
docs: new docs page for USDC and CCTP in defi developers

### DIFF
--- a/.gitbook/developers-defi/usdc-stablecoin.mdx
+++ b/.gitbook/developers-defi/usdc-stablecoin.mdx
@@ -22,7 +22,7 @@ for cross-chain transfers via CCTP, and as a settlement currency in DeFi applica
 
 | Contract | Address |
 | --- | --- |
-| USDC | [`0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989`](https://blockscout.injective.network/address/0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989) |
+| USDC | *Coming soon* |
 
 <Info>
 USDC CCTP on Injective Mainnet: *Coming soon*

--- a/.gitbook/developers-defi/usdc-stablecoin.mdx
+++ b/.gitbook/developers-defi/usdc-stablecoin.mdx
@@ -9,7 +9,7 @@ updatedAt: "2026-04-23"
 USDC is available on Injective as a **native stablecoin** through
 [Circle's Cross-Chain Transfer Protocol (CCTP)](https://www.circle.com/cross-chain-transfer-protocol).
 USDC on Injective implements the [MultiVM Token Standard (MTS)](/developers-evm/multivm-token-standard),
-which means the same token is accessible across both the EVM and Cosmos execution environments without bridging.
+which means the same token is accessible across both the EVM and Cosmos protocols on Injective networks, without bridging.
 
 You can use USDC for trading on Injective's on-chain order book, as collateral for derivatives markets,
 for cross-chain transfers via CCTP, and as a settlement currency in DeFi applications built on Injective.

--- a/.gitbook/developers-defi/usdc-stablecoin.mdx
+++ b/.gitbook/developers-defi/usdc-stablecoin.mdx
@@ -78,8 +78,6 @@ Use the following faucets to obtain testnet USDC and INJ for development:
 </Accordion>
 
 <Accordion title="How do you get USDC on Injective Testnet?">
-  On Injective Mainnet, you can transfer USDC to Injective from other supported chains using
-  [Circle's CCTP](https://www.circle.com/cross-chain-transfer-protocol).
   On Injective Testnet, you can obtain Testnet USDC from the [Circle Faucet](https://faucet.circle.com/).
   You will likely also need to use the [Injective Testnet Faucet](https://testnet.faucet.injective.network/) to obtain Testnet INJ,
   in order to pay for transactions.
@@ -119,7 +117,7 @@ Use the following faucets to obtain testnet USDC and INJ for development:
   <Card title="USDC Smart Contracts Addresses" icon="location" href="https://developers.circle.com/stablecoins/usdc-contract-addresses">
     The official/canonical reference for Circle smart contract deployments for USDC.
   </Card>
-  <Card title="Circle Smart Contracts Addresses" icon="stamp" href="https://developers.circle.com/cctp/references/contract-addresses">
+  <Card title="USDC CCTP Smart Contracts Addresses" icon="stamp" href="https://developers.circle.com/cctp/references/contract-addresses">
     The official/canonical reference for Circle smart contract deployments for USDC CCTP.
   </Card>
 </CardGroup>

--- a/.gitbook/developers-defi/usdc-stablecoin.mdx
+++ b/.gitbook/developers-defi/usdc-stablecoin.mdx
@@ -1,0 +1,125 @@
+---
+title: USDC on Injective
+description: >-
+  USDC stablecoin contract addresses, CCTP integration details, and testnet faucet
+  information for building with USDC on Injective.
+updatedAt: "2026-04-23"
+---
+
+USDC is available on Injective as a **native stablecoin** through
+[Circle's Cross-Chain Transfer Protocol (CCTP)](https://www.circle.com/cross-chain-transfer-protocol).
+USDC on Injective implements the [MultiVM Token Standard (MTS)](/developers-evm/multivm-token-standard),
+which means the same token is accessible across both the EVM and Cosmos execution environments without bridging.
+
+You can use USDC for trading on Injective's on-chain order book, as collateral for derivatives markets,
+for cross-chain transfers via CCTP, and as a settlement currency in DeFi applications built on Injective.
+
+## Contract addresses
+
+<Tabs>
+
+<Tab title="Mainnet" icon="server">
+
+| Contract | Address |
+| --- | --- |
+| USDC | [`0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989`](https://blockscout.injective.network/address/0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989) |
+
+<Info>
+USDC CCTP on Injective Mainnet: *Coming soon*
+</Info>
+
+</Tab>
+
+<Tab title="Testnet" icon="flask-vial">
+
+| Contract | Address |
+| --- | --- |
+| USDC | [`0x0C382e685bbeeFE5d3d9C29e29E341fEE8E84C5d`](https://testnet.blockscout.injective.network/token/0x0C382e685bbeeFE5d3d9C29e29E341fEE8E84C5d) |
+| USDC CCTP `TokenMessengerV2` | [`0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA`](https://testnet.blockscout.injective.network/address/0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA) |
+| USDC CCTP `MessageTransmitterV2` | [`0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275`](https://testnet.blockscout.injective.network/address/0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275) |
+| USDC CCTP `TokenMinterV2` | [`0xb43db544E2c27092c107639Ad201b3dEfAbcF192`](https://testnet.blockscout.injective.network/address/0xb43db544E2c27092c107639Ad201b3dEfAbcF192) |
+| USDC CCTP `MessageV2` | [`0xbaC0179bB358A8936169a63408C8481D582390C4`](https://testnet.blockscout.injective.network/address/0xbaC0179bB358A8936169a63408C8481D582390C4) |
+
+<Info>
+USDC CCTP domain ID for Injective Testnet: `29`
+</Info>
+
+</Tab>
+
+</Tabs>
+
+## Testnet faucets
+
+Use the following faucets to obtain testnet USDC and INJ for development:
+
+| Faucet | Purpose | URL |
+| --- | --- | --- |
+| Circle USDC Faucet | USDC | [`faucet.circle.com`](https://faucet.circle.com/) |
+| Injective Faucet | INJ | [`testnet.faucet.injective.network`](https://testnet.faucet.injective.network/) |
+| Google Cloud Faucet | INJ | [`cloud.google.com/application/web3/faucet/injective/testnet`](https://cloud.google.com/application/web3/faucet/injective/testnet) |
+
+## Frequently asked questions
+
+<Accordion title="What is USDC on Injective?">
+  USDC on Injective is a native deployment of Circle's USD Coin stablecoin.
+  It is backed 1:1 by US dollar reserves held by Circle and is transferred to Injective through the Cross-Chain Transfer Protocol (CCTP).
+  USDC on Injective follows the MultiVM Token Standard (MTS),
+  making it usable across both the EVM and Cosmos protocols of the Injective blockchain network.
+</Accordion>
+
+<Accordion title="Where can I verify the smart contract addresses for USDC, and USDC CCTP?">
+  The information provided above is for your convenience only.
+  You should always consult Circle's documentation as the *canonical source* for smart contract addresses,
+  and USDC CCTP domain IDs.
+
+  References:
+  - [USDC smart contract addresses](https://developers.circle.com/stablecoins/usdc-contract-addresses)
+  - [USDC CCTP smart contract addresses for EVM-compatible blockchains](https://developers.circle.com/cctp/references/contract-addresses)
+</Accordion>
+
+<Accordion title="How do you get USDC on Injective Testnet?">
+  On Injective Mainnet, you can transfer USDC to Injective from other supported chains using
+  [Circle's CCTP](https://www.circle.com/cross-chain-transfer-protocol).
+  On Injective Testnet, you can obtain Testnet USDC from the [Circle Faucet](https://faucet.circle.com/).
+  You will likely also need to use the [Injective Testnet Faucet](https://testnet.faucet.injective.network/) to obtain Testnet INJ,
+  in order to pay for transactions.
+  You may also use [Circle's CCTP](https://www.circle.com/cross-chain-transfer-protocol)
+  to transfer USDC from other supported networks.
+</Accordion>
+
+<Accordion title="How do you get USDC on Injective Mainnet?">
+  **Coming soon**:
+  On Injective Mainnet, you will be able to transfer USDC to Injective from other supported networks using
+  [Circle's CCTP](https://www.circle.com/cross-chain-transfer-protocol).
+</Accordion>
+
+<Accordion title="What is CCTP on Injective?">
+  The Cross-Chain Transfer Protocol (CCTP) is Circle's native cross-chain infrastructure that enables
+  USDC to be transferred between blockchain networks.
+  On Injective, CCTP V2 contracts (`TokenMessengerV2`, `MessageTransmitterV2`, `TokenMinterV2`, and `MessageV2`)
+  handle the minting and burning of USDC for cross-chain transfers.
+</Accordion>
+
+<Accordion title="Can USDC be used across both EVM and Cosmos on Injective?">
+  Yes.
+  USDC on Injective follows the [MultiVM Token Standard (MTS)](/developers-evm/multivm-token-standard),
+  which means the same token balance is accessible from both EVM smart contracts and Cosmos-based modules.
+  There is no need to bridge or wrap USDC when moving between the two execution environments.
+</Accordion>
+
+## Related resources
+
+<CardGroup cols={2}>
+  <Card title="MultiVM Token Standard" icon="arrows-repeat" href="/developers-evm/multivm-token-standard">
+    Learn how tokens work across EVM and Cosmos on Injective.
+  </Card>
+  <Card title="EVM Network Information" icon="network-wired" href="/developers-evm/network-information">
+    RPC endpoints, chain IDs, and other EVM network details.
+  </Card>
+  <Card title="USDC Smart Contracts Addresses" icon="location" href="https://developers.circle.com/stablecoins/usdc-contract-addresses">
+    The official/canonical reference for Circle smart contract deployments for USDC.
+  </Card>
+  <Card title="Circle Smart Contracts Addresses" icon="stamp" href="https://developers.circle.com/cctp/references/contract-addresses">
+    The official/canonical reference for Circle smart contract deployments for USDC CCTP.
+  </Card>
+</CardGroup>

--- a/.gitbook/developers-evm/network-information.mdx
+++ b/.gitbook/developers-evm/network-information.mdx
@@ -79,11 +79,9 @@ See [Injective Testnet network information](/developers/network-information/#inj
 
 * **wINJ** wrapped INJ (MTS) - [`0x0000000088827d2d103ee2d9A6b781773AE03FfB`](https://testnet.blockscout.injective.network/address/0x0000000088827d2d103ee2d9A6b781773AE03FfB)
 * **USDT** USDT (MTS) - [`0xaDC7bcB5d8fe053Ef19b4E0C861c262Af6e0db60`](https://testnet.blockscout.injective.network/address/0xaDC7bcB5d8fe053Ef19b4E0C861c262Af6e0db60)
-* **USDC** - [`0x0C382e685bbeeFE5d3d9C29e29E341fEE8E84C5d`](https://testnet.blockscout.injective.network/token/0x0C382e685bbeeFE5d3d9C29e29E341fEE8E84C5d)
-* **USDC CCTP TokenMessengerV2** - [`0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA`](https://testnet.blockscout.injective.network/address/0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA)
-* **USDC CCTP MessageTransmitterV2** - [`0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275`](https://testnet.blockscout.injective.network/address/0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275)
-* **USDC CCTP TokenMinterV2** - [`0xb43db544E2c27092c107639Ad201b3dEfAbcF192`](https://testnet.blockscout.injective.network/address/0xb43db544E2c27092c107639Ad201b3dEfAbcF192)
-* **USDC CCTP MessageV2** - [`0xbaC0179bB358A8936169a63408C8481D582390C4`](https://testnet.blockscout.injective.network/address/0xbaC0179bB358A8936169a63408C8481D582390C4)
+<Info>
+For USDC and CCTP contract addresses, see [USDC on Injective](/developers-defi/usdc-stablecoin).
+</Info>
 
 <Callout icon="info" color="#07C1FF" iconType="regular">
 Note that tokens that are **MTS** follow the [MultiVM Token Standard](https://docs.injective.network/developers-evm/multivm-token-standard).

--- a/.gitbook/developers-evm/network-information.mdx
+++ b/.gitbook/developers-evm/network-information.mdx
@@ -3,7 +3,7 @@ title: EVM Network Information
 description: >-
     Essential information about the Injective EVM network.
     Chain IDs, RPC endpoints, block explorer URLs, and network configuration for Injective's EVM layer.
-updatedAt: "2026-03-18"
+updatedAt: "2026-5-23"
 ---
 
 <Tabs>
@@ -19,27 +19,33 @@ updatedAt: "2026-03-18"
 * Explorer: [`blockscout.injective.network`](https://blockscout.injective.network/)
 * Explorer API: `https://blockscout-api.injective.network/api`
 
-<Callout icon="info" color="#07C1FF" iconType="regular">
+<Info>
 Note that the Injective Chain ID is natively `injective-1`.
 However, EVM uses a numeric chain ID of `1776`.
 While these are different, they map to the **same** network.
 
 See [Injective Mainnet network information](/developers/network-information/#injective-mainnet) for more details.
-</Callout>
+</Info>
 
 ## Contracts
 
-* **USDT** USDT (MTS) - [`0x88f7F2b685F9692caf8c478f5BADF09eE9B1Cc13`](https://blockscout.injective.network/address/0x88f7F2b685F9692caf8c478f5BADF09eE9B1Cc13)
-* **wETH** wrapped ETH (MTS) - [`0x83A15000b753AC0EeE06D2Cb41a69e76D0D5c7F7`](https://blockscout.injective.network/address/0x83A15000b753AC0EeE06D2Cb41a69e76D0D5c7F7)
-* **wINJ** wrapped INJ (MTS) - [`0x0000000088827d2d103ee2d9A6b781773AE03FfB`](https://blockscout.injective.network/address/0x0000000088827d2d103ee2d9A6b781773AE03FfB)
-* **USDC** USDC (MTS) - [`0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989`](https://blockscout.injective.network/address/0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989)
-* **MultiCall** - [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://blockscout.injective.network/address/0xcA11bde05977b3631167028862bE2a173976CA11)
+* **wINJ** wrapped INJ (MTS) -
+  [`0x0000000088827d2d103ee2d9A6b781773AE03FfB`](https://blockscout.injective.network/address/0x0000000088827d2d103ee2d9A6b781773AE03FfB)
+* **wETH** wrapped ETH (MTS) -
+  [`0x83A15000b753AC0EeE06D2Cb41a69e76D0D5c7F7`](https://blockscout.injective.network/address/0x83A15000b753AC0EeE06D2Cb41a69e76D0D5c7F7)
+* **USDC** USD Coin (MTS) -
+  See [USDC on Injective](/developers-defi/usdc-stablecoin) for the addresses of USDC and USDC CCTP smart contracts.
+* **USDT** USDT (MTS) -
+  [`0x88f7F2b685F9692caf8c478f5BADF09eE9B1Cc13`](https://blockscout.injective.network/address/0x88f7F2b685F9692caf8c478f5BADF09eE9B1Cc13)
+* **MultiCall** -
+  [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://blockscout.injective.network/address/0xcA11bde05977b3631167028862bE2a173976CA11)
 
-<Callout icon="info" color="#07C1FF" iconType="regular">
-Note that tokens that are **MTS** follow the [MultiVM Token Standard](https://docs.injective.network/developers-evm/multivm-token-standard).
+<Info>
+Note that tokens that are **MTS** follow the
+[MultiVM Token Standard](https://docs.injective.network/developers-evm/multivm-token-standard).
 
 This means the same token can be used in all Injective modules (EVM, Cosmos) without using a bridge.
-</Callout>
+</Info>
 
 ## More Providers
 
@@ -69,36 +75,40 @@ This means the same token can be used in all Injective modules (EVM, Cosmos) wit
 * Explorer API: `https://testnet.blockscout-api.injective.network/api`
 
 
-<Callout icon="info" color="#07C1FF" iconType="regular">
-Note that the Injective Chain ID is natively `injective-888`. However, EVM uses a numeric chain ID of `1439`. While these are different, they map to the **same** network.
+<Info>
+Note that the Injective Chain ID is natively `injective-888`.
+However, EVM uses a numeric chain ID of `1439`.
+While these are different, they map to the **same** network.
 
 See [Injective Testnet network information](/developers/network-information/#injective-testnet) for more details.
-</Callout>
+</Info>
 
 ## Contracts
 
-* **wINJ** wrapped INJ (MTS) - [`0x0000000088827d2d103ee2d9A6b781773AE03FfB`](https://testnet.blockscout.injective.network/address/0x0000000088827d2d103ee2d9A6b781773AE03FfB)
-* **USDT** USDT (MTS) - [`0xaDC7bcB5d8fe053Ef19b4E0C861c262Af6e0db60`](https://testnet.blockscout.injective.network/address/0xaDC7bcB5d8fe053Ef19b4E0C861c262Af6e0db60)
-<Info>
-For USDC and CCTP contract addresses, see [USDC on Injective](/developers-defi/usdc-stablecoin).
-</Info>
+* **wINJ** wrapped INJ (MTS) -
+  [`0x0000000088827d2d103ee2d9A6b781773AE03FfB`](https://testnet.blockscout.injective.network/address/0x0000000088827d2d103ee2d9A6b781773AE03FfB)
+* **USDC** USD Coin (MTS) -
+  See [USDC on Injective](/developers-defi/usdc-stablecoin) for the addresses of USDC and USDC CCTP smart contracts.
+* **USDT** USDT (MTS) -
+  [`0xaDC7bcB5d8fe053Ef19b4E0C861c262Af6e0db60`](https://testnet.blockscout.injective.network/address/0xaDC7bcB5d8fe053Ef19b4E0C861c262Af6e0db60)
 
-<Callout icon="info" color="#07C1FF" iconType="regular">
-Note that tokens that are **MTS** follow the [MultiVM Token Standard](https://docs.injective.network/developers-evm/multivm-token-standard).
+<Info>
+Note that tokens that are **MTS** follow the
+[MultiVM Token Standard](https://docs.injective.network/developers-evm/multivm-token-standard).
 
 This means the same token can be used in all Injective modules (EVM, Cosmos) without using a bridge.
-</Callout>
+</Info>
 
 ## More Providers
 
 * Explorers
   * Blockscout mirror: [`testnet-injective.cloud.blockscout.com/`](https://testnet-injective.cloud.blockscout.com/)
 * JSON-RPC Providers
-  * Quicknode [`quicknode.com/chains/inj`](https://www.quicknode.com/chains/inj)
-    * Note that you will need to create an account on quicknode to obtain an endpoint URL
+  * Quicknode: [`quicknode.com/chains/inj`](https://www.quicknode.com/chains/inj)
+    * Note that you will need to create an account on Quicknode to obtain an endpoint URL
     * [Quicknode JSON-RPC documentation](https://www.quicknode.com/docs/injective/evm/eth_blockNumber)
-  * ThirdWeb [`thirdweb.com/injective-evm-testnet`](https://thirdweb.com/injective-evm-testnet)
-    * Note that you will need to create an account on thirdweb to obtain an endpoint URL
+  * ThirdWeb: [`thirdweb.com/injective-evm-testnet`](https://thirdweb.com/injective-evm-testnet)
+    * Note that you will need to create an account on ThirdWeb to obtain an endpoint URL
     * [ThirdWeb Playground](https://playground.thirdweb.com/)
 
 ## More Info

--- a/.gitbook/docs.json
+++ b/.gitbook/docs.json
@@ -363,6 +363,7 @@
                   "developers-defi/market-launch",
                   "developers-defi/denom-and-bank",
                   "developers-defi/provider-oracle",
+                  "developers-defi/usdc-stablecoin",
                   {
                     "group": "Injective Trader",
                     "expanded": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "USDC on Injective" doc covering testnet/mainnet addresses, CCTP details, MultiVM Token Standard usage, testnet faucets, FAQs, and related resources.
  * Updated network information content to reference the new USDC doc for contract addresses and adjusted informational callouts and contract listings.
  * Updated site navigation to include the new USDC on Injective page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->