### PR TITLE
docs: add v1.20 validator flag changes

### DIFF
--- a/.gitbook/docs.json
+++ b/.gitbook/docs.json
@@ -231,6 +231,7 @@
                       "infra/validator-mainnet/peggo",
                       "infra/validator-mainnet/canonical-chain-upgrade",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.20.0",
+                      "infra/validator-mainnet/validator-v1.20-flag-changes",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.19.0",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.18.3",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.18.2",

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0.mdx
@@ -11,6 +11,7 @@ Following [IIP-650](https://injhub.com/proposal/650/) This indicates that the up
 * [Recovery](#recovery)
 * [Upgrade Procedure](#upgrade-procedure)
 * [Notes for Validators](#notes-for-validators)
+* [Breaking Changes - MUST REVIEW](#breaking-changes)
 
 ## Summary
 
@@ -52,6 +53,8 @@ You must remove the wasm cache before upgrading to the new version:
 ```shell
 rm -rf .injectived/wasm/wasm/cache/
 ```
+
+## Breaking Changes - MUST REVIEW
 
 Review the [v1.20.0 validator startup flag changes](./validator-v1.20-flag-changes/) before restarting `injectived`. Deprecated flags must be removed, renamed flags should be updated, and changed defaults should be pinned explicitly if your node depends on the previous behavior.
 

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0.mdx
@@ -53,6 +53,8 @@ You must remove the wasm cache before upgrading to the new version:
 rm -rf .injectived/wasm/wasm/cache/
 ```
 
+Review the [v1.20.0 validator startup flag changes](./validator-v1.20-flag-changes/) before restarting `injectived`. Deprecated flags must be removed, renamed flags should be updated, and changed defaults should be pinned explicitly if your node depends on the previous behavior.
+
 ### Steps
 
 1.  Verify you are currently running the correct version (`v1.19.0`) of `injectived`:

--- a/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
+++ b/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
@@ -1,0 +1,102 @@
+---
+title: v1.20.0 validator startup flag changes
+updatedAt: "2026-06-02"
+---
+
+This page summarizes `injectived start` flag changes between `v1.19.0` and `v1.20.0`. Validators should review startup scripts, Helm charts, systemd units, and Kubernetes manifests before upgrading.
+
+## Recommended upgrade checklist
+
+1. Remove flags that no longer exist.
+2. Rename metrics and ChainStream flags if you use them.
+3. Pin any changed defaults if your node depends on the old behavior.
+
+## Long-term configuration recommendation
+
+Prefer setting persistent node configuration in the appropriate config file:
+
+* Use `app.toml` for application-level settings such as API, gRPC, JSON-RPC, pruning, metrics, ChainStream, EVM, and Injective websocket configuration.
+* Use `config.toml` for CometBFT settings such as P2P, RPC, consensus, and mempool configuration.
+
+Startup flags should be treated as temporary overrides for testing, emergency operations, or short-lived rollout changes. They should not be used as the permanent replacement for values that belong in `app.toml` or `config.toml`.
+
+Keeping long-lived settings in config files makes validator behavior easier to audit, reduces upgrade risk when flags are renamed or removed, and keeps startup commands stable across releases.
+
+## Renamed or replaced flags
+
+Update any startup configuration that still uses the old flag names.
+
+| v1.19.0 flag | v1.20.0 flag | Notes |
+| --- | --- | --- |
+| `--metrics-enable-metrics=false` | `--metrics.metrics-enabled=false` | Same default. |
+| `--metrics-enable-tracing=false` | `--metrics.tracing-enabled=false` | Same default. |
+| `--metrics-endpoint=localhost:4317` | `--metrics.endpoint=localhost:4317` | Same default. |
+| `--metrics-insecure=false` | `--metrics.insecure-endpoint=false` | Same default. |
+| `--metrics-export-interval=10s` | `--metrics.export-interval=10s` | Now parsed as a duration and used by metrics export. |
+| `--metrics-stuck-func=0m` | `--metrics.stuck-func-timeout=0s` | Same effective disabled default. |
+| `--trace-flight-recorder-threshold=0` | `--metrics.flight-recorder-threshold=0s` | Same effective disabled default. |
+| `--log-color=true` | `--log-no-color=false` | Behavior is inverted. |
+| `--chainstream-server=""` | `--chainstream.server=""` | Same default. |
+| `--chainstream-buffer-cap=100` | `--chainstream.buffer-cap=100` | Same default. |
+| `--chainstream-publisher-buffer-cap=100` | `--chainstream.publisher-buffer-cap=100` | Same default. |
+| `--chainstream-enforce-keepalive=false` | `--chainstream.enforce-keepalive=false` | Same default. |
+| `--chainstream-min-client-ping-interval=30` | `--chainstream.min-client-ping-interval=30` | Same default. |
+| `--chainstream-max-connection-idle=180` | `--chainstream.max-connection-idle=180` | Same default. |
+| `--chainstream-server-ping-interval=60` | `--chainstream.server-ping-interval=60` | Same default. |
+| `--chainstream-server-ping-response-timeout=40` | `--chainstream.server-ping-response-timeout=40` | Same default. |
+
+## Added flags
+
+These flags did not exist as `injectived start` flags in `v1.19.0`. No change is needed if these values are picked up from the config files as usual.
+
+| v1.20.0 flag | Default | Notes |
+| --- | --- | --- |
+| `--app-db-backend` | `""` | Empty value falls back to the CometBFT DB backend. |
+| `--index-events` | `[]` | Controls event indexing for CometBFT. Empty means all events are indexed. |
+| `--chain-id` | `injective-1` | New on `start`. |
+| `--injective-websocket.address` | `""` | Empty value disables the Injective websocket server. |
+| `--injective-websocket.max-open-connections` | `0` | Unlimited. |
+| `--injective-websocket.read-timeout` | `10s` | HTTP read timeout. |
+| `--injective-websocket.write-timeout` | `10s` | HTTP write timeout. |
+| `--injective-websocket.max-body-bytes` | `1000000` | Maximum allowed request body size. |
+| `--injective-websocket.max-header-bytes` | `1048576` | Maximum allowed header size. |
+| `--injective-websocket.max-request-batch-size` | `10` | Maximum JSON-RPC requests per batch. |
+
+## Removed flags
+
+Remove these from startup scripts before running `v1.20.0`.
+
+| Removed flag | Previous default | Replacement |
+| --- | --- | --- |
+| `--with-comet` | `true` | None. In-process CometBFT startup is now the supported path. |
+| `--with-tendermint` | Alias for `--with-comet` | None. |
+| `--address` | `tcp://0.0.0.0:26658` | None for normal validator startup. |
+| `--transport` | `socket` | None for normal validator startup. |
+| `--pruning-keep-every` | `0` | None. Use `--pruning`, `--pruning-keep-recent`, and `--pruning-interval`. |
+| `--multistore-commit-sync` | `false` | None. This flag was registered in `v1.19.0` but not consumed by Injective startup code. |
+
+## Same name, changed default or type
+
+If your deployment relied on the old default, set the old value explicitly.
+
+| Flag | v1.19.0 | v1.20.0 | Suggested validator action |
+| --- | --- | --- | --- |
+| `--minimum-gas-prices` | `""` | `160000000inj` | Pin explicitly if you require a different minimum gas price. |
+| `--pruning` | `default` | `nothing` | Pin `--pruning=default` if you do not want archive-style behavior. |
+| `--pruning-keep-recent` | `uint64(0)` | string `"0"` | Usually no action; type changed for config parsing. |
+| `--pruning-interval` | `uint64(0)` | string `"0"` | Usually no action; type changed for config parsing. |
+| `--iavl-cache-size` | `int(500000)` | `uint64(781250)` | Pin old value if memory/cache sizing depends on it. |
+| `--api.enable` | `false` flag default | `true` flag default | Pin `--api.enable=false` if the REST API must remain disabled. |
+| `--api.swagger` | `false` flag default | `true` flag default | Pin `--api.swagger=false` if Swagger must remain disabled. |
+| `--api.address` | `tcp://localhost:1317` | `tcp://0.0.0.0:10337` | Pin old address if exposing the API is not intended. |
+| `--api.enabled-unsafe-cors` | `false` flag default | `true` flag default | Pin `false` if CORS must remain disabled. |
+| `--json-rpc.api` | unset / nil | `[eth, net, web3, inj]` | Pin explicitly if you require a different namespace set. |
+| `--json-rpc-debug.api` | `[debug]` | `[eth, debug, inj]` | Pin explicitly if debug RPC is enabled and should stay debug-only. |
+| `--json-rpc.max-open-connections` | `uint(0)` | `int(0)` | Usually no action; value remains unlimited. |
+| `--json-rpc.return-data-limit` | `uint(512000)` | `int64(512000)` | Usually no action; value is unchanged. |
+| `--json-rpc-debug.max-open-connections` | `uint(0)` | `int(0)` | Usually no action; value remains unlimited. |
+| `--json-rpc-debug.return-data-limit` | `uint(10485760)` | `int64(10485760)` | Usually no action; value is unchanged. |
+| `--log-level` | `info` | `""` | Pin explicitly if you require a specific log level. |
+| `--log-format` | `plain` | `""` | Pin explicitly if you require `plain` or `json`. |
+
+For `--api.*`, generated Injective `app.toml` defaults were already set to enabled in `v1.19.0`; the notable change is the effective CLI flag default used by `injectived start`.

--- a/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
+++ b/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
@@ -34,7 +34,7 @@ for the `v1.20.0` tag can be found at the bottom of this file.
 
 Update any startup configuration that still uses the old flag names.
 
-| v1.19.0 flag                                    | v1.20.0 flag                               | Notes                                                |
+| v1.19.0 flag                                    | v1.20.0 flag                                    | Notes                                                |
 | ----------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------- |
 | `--metrics-enable-metrics=false`                | `--metrics.metrics-enabled=false`               | Same default.                                        |
 | `--metrics-enable-tracing=false`                | `--metrics.tracing-enabled=false`               | Same default.                                        |
@@ -57,7 +57,7 @@ Update any startup configuration that still uses the old flag names.
 
 These flags did not exist as `injectived start` flags in `v1.19.0`.
 
-| v1.20.0 flag                              | Default       | Notes                                                                     |
+| v1.20.0 flag                                   | Default       | Notes                                                                     |
 | ---------------------------------------------- | ------------- | ------------------------------------------------------------------------- |
 | `--app-db-backend`                             | `""`          | Empty value falls back to the CometBFT DB backend.                        |
 | `--index-events`                               | `[]`          | Controls event indexing for CometBFT. Empty means all events are indexed. |
@@ -87,7 +87,7 @@ Remove these from startup scripts before running `v1.20.0`.
 
 If your deployment relied on the old default, set the old value explicitly.
 
-| Flag                                    | v1.19.0                | v1.20.0            | Suggested validator action                                         |
+| Flag                                    | v1.19.0                | v1.20.0                 | Suggested validator action                                         |
 | --------------------------------------- | ---------------------- | ----------------------- | ------------------------------------------------------------------ |
 | `--minimum-gas-prices`                  | `""`                   | `160000000inj`          | Pin explicitly if you require a different minimum gas price.       |
 | `--pruning`                             | `default`              | `nothing`               | Pin `--pruning=default` if you do not want archive-style behavior. |

--- a/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
+++ b/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
@@ -1,102 +1,1147 @@
 ---
-title: v1.20.0 validator startup flag changes
+title: Validator Startup Flag Changes for v1.20.0-beta
 updatedAt: "2026-06-02"
 ---
 
-This page summarizes `injectived start` flag changes between `v1.19.0` and `v1.20.0`. Validators should review startup scripts, Helm charts, systemd units, and Kubernetes manifests before upgrading.
+This note summarizes `injectived start` flag changes between `v1.19.0` and
+`v1.20.0`. Validators should review their startup scripts, Helm charts,
+systemd units, or Kubernetes manifests before upgrading.
 
-## Recommended upgrade checklist
+## Recommended Upgrade Checklist
 
 1. Remove flags that no longer exist.
 2. Rename metrics and ChainStream flags if you use them.
 3. Pin any changed defaults if your node depends on the old behavior.
 
-## Long-term configuration recommendation
+## Long-Term Configuration Recommendation
 
 Prefer setting persistent node configuration in the appropriate config file:
 
-* Use `app.toml` for application-level settings such as API, gRPC, JSON-RPC, pruning, metrics, ChainStream, EVM, and Injective websocket configuration.
-* Use `config.toml` for CometBFT settings such as P2P, RPC, consensus, and mempool configuration.
+- Use `app.toml` for application-level settings such as API, gRPC, JSON-RPC,
+  pruning, metrics, ChainStream, EVM, and Injective websocket configuration.
+- Use `config.toml` for CometBFT settings such as P2P, RPC, consensus, and
+  mempool configuration.
 
-Startup flags should be treated as temporary overrides for testing, emergency operations, or short-lived rollout changes. They should not be used as the permanent replacement for values that belong in `app.toml` or `config.toml`.
+Startup flags should be treated as temporary overrides for testing, emergency
+operations, or short-lived rollout changes. They should not be used as the
+permanent replacement for values that belong in `app.toml` or `config.toml`.
+Keeping long-lived settings in config files makes validator behavior easier to
+audit, reduces upgrade risk when flags are renamed or removed, and keeps startup
+commands stable across releases. The template `app.toml` and `config.toml` files
+for the `v1.20.0` tag can be found at the bottom of this file.
 
-Keeping long-lived settings in config files makes validator behavior easier to audit, reduces upgrade risk when flags are renamed or removed, and keeps startup commands stable across releases.
-
-## Renamed or replaced flags
+## Renamed or Replaced Flags
 
 Update any startup configuration that still uses the old flag names.
 
-| v1.19.0 flag | v1.20.0 flag | Notes |
-| --- | --- | --- |
-| `--metrics-enable-metrics=false` | `--metrics.metrics-enabled=false` | Same default. |
-| `--metrics-enable-tracing=false` | `--metrics.tracing-enabled=false` | Same default. |
-| `--metrics-endpoint=localhost:4317` | `--metrics.endpoint=localhost:4317` | Same default. |
-| `--metrics-insecure=false` | `--metrics.insecure-endpoint=false` | Same default. |
-| `--metrics-export-interval=10s` | `--metrics.export-interval=10s` | Now parsed as a duration and used by metrics export. |
-| `--metrics-stuck-func=0m` | `--metrics.stuck-func-timeout=0s` | Same effective disabled default. |
-| `--trace-flight-recorder-threshold=0` | `--metrics.flight-recorder-threshold=0s` | Same effective disabled default. |
-| `--log-color=true` | `--log-no-color=false` | Behavior is inverted. |
-| `--chainstream-server=""` | `--chainstream.server=""` | Same default. |
-| `--chainstream-buffer-cap=100` | `--chainstream.buffer-cap=100` | Same default. |
-| `--chainstream-publisher-buffer-cap=100` | `--chainstream.publisher-buffer-cap=100` | Same default. |
-| `--chainstream-enforce-keepalive=false` | `--chainstream.enforce-keepalive=false` | Same default. |
-| `--chainstream-min-client-ping-interval=30` | `--chainstream.min-client-ping-interval=30` | Same default. |
-| `--chainstream-max-connection-idle=180` | `--chainstream.max-connection-idle=180` | Same default. |
-| `--chainstream-server-ping-interval=60` | `--chainstream.server-ping-interval=60` | Same default. |
-| `--chainstream-server-ping-response-timeout=40` | `--chainstream.server-ping-response-timeout=40` | Same default. |
+| v1.19.0 flag                                    | v1.20.0-beta flag                               | Notes                                                |
+| ----------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------- |
+| `--metrics-enable-metrics=false`                | `--metrics.metrics-enabled=false`               | Same default.                                        |
+| `--metrics-enable-tracing=false`                | `--metrics.tracing-enabled=false`               | Same default.                                        |
+| `--metrics-endpoint=localhost:4317`             | `--metrics.endpoint=localhost:4317`             | Same default.                                        |
+| `--metrics-insecure=false`                      | `--metrics.insecure-endpoint=false`             | Same default.                                        |
+| `--metrics-export-interval=10s`                 | `--metrics.export-interval=10s`                 | Now parsed as a duration and used by metrics export. |
+| `--metrics-stuck-func=0m`                       | `--metrics.stuck-func-timeout=0s`               | Same effective disabled default.                     |
+| `--trace-flight-recorder-threshold=0`           | `--metrics.flight-recorder-threshold=0s`        | Same effective disabled default.                     |
+| `--log-color=true`                              | `--log-no-color=false`                          | Behavior is inverted.                                |
+| `--chainstream-server=""`                       | `--chainstream.server=""`                       | Same default.                                        |
+| `--chainstream-buffer-cap=100`                  | `--chainstream.buffer-cap=100`                  | Same default.                                        |
+| `--chainstream-publisher-buffer-cap=100`        | `--chainstream.publisher-buffer-cap=100`        | Same default.                                        |
+| `--chainstream-enforce-keepalive=false`         | `--chainstream.enforce-keepalive=false`         | Same default.                                        |
+| `--chainstream-min-client-ping-interval=30`     | `--chainstream.min-client-ping-interval=30`     | Same default.                                        |
+| `--chainstream-max-connection-idle=180`         | `--chainstream.max-connection-idle=180`         | Same default.                                        |
+| `--chainstream-server-ping-interval=60`         | `--chainstream.server-ping-interval=60`         | Same default.                                        |
+| `--chainstream-server-ping-response-timeout=40` | `--chainstream.server-ping-response-timeout=40` | Same default.                                        |
 
-## Added flags
+## Added Flags (Informational. No change needed as these values will be picked from the config files as usual)
 
-These flags did not exist as `injectived start` flags in `v1.19.0`. No change is needed if these values are picked up from the config files as usual.
+These flags did not exist as `injectived start` flags in `v1.19.0`.
 
-| v1.20.0 flag | Default | Notes |
-| --- | --- | --- |
-| `--app-db-backend` | `""` | Empty value falls back to the CometBFT DB backend. |
-| `--index-events` | `[]` | Controls event indexing for CometBFT. Empty means all events are indexed. |
-| `--chain-id` | `injective-1` | New on `start`. |
-| `--injective-websocket.address` | `""` | Empty value disables the Injective websocket server. |
-| `--injective-websocket.max-open-connections` | `0` | Unlimited. |
-| `--injective-websocket.read-timeout` | `10s` | HTTP read timeout. |
-| `--injective-websocket.write-timeout` | `10s` | HTTP write timeout. |
-| `--injective-websocket.max-body-bytes` | `1000000` | Maximum allowed request body size. |
-| `--injective-websocket.max-header-bytes` | `1048576` | Maximum allowed header size. |
-| `--injective-websocket.max-request-batch-size` | `10` | Maximum JSON-RPC requests per batch. |
+| v1.20.0-beta flag                              | Default       | Notes                                                                     |
+| ---------------------------------------------- | ------------- | ------------------------------------------------------------------------- |
+| `--app-db-backend`                             | `""`          | Empty value falls back to the CometBFT DB backend.                        |
+| `--index-events`                               | `[]`          | Controls event indexing for CometBFT. Empty means all events are indexed. |
+| `--chain-id`                                   | `injective-1` | New on `start`                                                            |
+| `--injective-websocket.address`                | `""`          | Empty value disables the Injective websocket server.                      |
+| `--injective-websocket.max-open-connections`   | `0`           | Unlimited.                                                                |
+| `--injective-websocket.read-timeout`           | `10s`         | HTTP read timeout.                                                        |
+| `--injective-websocket.write-timeout`          | `10s`         | HTTP write timeout.                                                       |
+| `--injective-websocket.max-body-bytes`         | `1000000`     | Maximum allowed request body size.                                        |
+| `--injective-websocket.max-header-bytes`       | `1048576`     | Maximum allowed header size.                                              |
+| `--injective-websocket.max-request-batch-size` | `10`          | Maximum JSON-RPC requests per batch.                                      |
 
-## Removed flags
+## Removed Flags
 
 Remove these from startup scripts before running `v1.20.0`.
 
-| Removed flag | Previous default | Replacement |
-| --- | --- | --- |
-| `--with-comet` | `true` | None. In-process CometBFT startup is now the supported path. |
-| `--with-tendermint` | Alias for `--with-comet` | None. |
-| `--address` | `tcp://0.0.0.0:26658` | None for normal validator startup. |
-| `--transport` | `socket` | None for normal validator startup. |
-| `--pruning-keep-every` | `0` | None. Use `--pruning`, `--pruning-keep-recent`, and `--pruning-interval`. |
-| `--multistore-commit-sync` | `false` | None. This flag was registered in `v1.19.0` but not consumed by Injective startup code. |
+| Removed flag               | Previous default         | Replacement                                                                             |
+| -------------------------- | ------------------------ | --------------------------------------------------------------------------------------- |
+| `--with-comet`             | `true`                   | None. In-process CometBFT startup is now the supported path.                            |
+| `--with-tendermint`        | Alias for `--with-comet` | None.                                                                                   |
+| `--address`                | `tcp://0.0.0.0:26658`    | None for normal validator startup.                                                      |
+| `--transport`              | `socket`                 | None for normal validator startup.                                                      |
+| `--pruning-keep-every`     | `0`                      | None. Use `--pruning`, `--pruning-keep-recent`, and `--pruning-interval`.               |
+| `--multistore-commit-sync` | `false`                  | None. This flag was registered in `v1.19.0` but not consumed by Injective startup code. |
 
-## Same name, changed default or type
+## Same Name, Changed Default or Type
 
 If your deployment relied on the old default, set the old value explicitly.
 
-| Flag | v1.19.0 | v1.20.0 | Suggested validator action |
-| --- | --- | --- | --- |
-| `--minimum-gas-prices` | `""` | `160000000inj` | Pin explicitly if you require a different minimum gas price. |
-| `--pruning` | `default` | `nothing` | Pin `--pruning=default` if you do not want archive-style behavior. |
-| `--pruning-keep-recent` | `uint64(0)` | string `"0"` | Usually no action; type changed for config parsing. |
-| `--pruning-interval` | `uint64(0)` | string `"0"` | Usually no action; type changed for config parsing. |
-| `--iavl-cache-size` | `int(500000)` | `uint64(781250)` | Pin old value if memory/cache sizing depends on it. |
-| `--api.enable` | `false` flag default | `true` flag default | Pin `--api.enable=false` if the REST API must remain disabled. |
-| `--api.swagger` | `false` flag default | `true` flag default | Pin `--api.swagger=false` if Swagger must remain disabled. |
-| `--api.address` | `tcp://localhost:1317` | `tcp://0.0.0.0:10337` | Pin old address if exposing the API is not intended. |
-| `--api.enabled-unsafe-cors` | `false` flag default | `true` flag default | Pin `false` if CORS must remain disabled. |
-| `--json-rpc.api` | unset / nil | `[eth, net, web3, inj]` | Pin explicitly if you require a different namespace set. |
-| `--json-rpc-debug.api` | `[debug]` | `[eth, debug, inj]` | Pin explicitly if debug RPC is enabled and should stay debug-only. |
-| `--json-rpc.max-open-connections` | `uint(0)` | `int(0)` | Usually no action; value remains unlimited. |
-| `--json-rpc.return-data-limit` | `uint(512000)` | `int64(512000)` | Usually no action; value is unchanged. |
-| `--json-rpc-debug.max-open-connections` | `uint(0)` | `int(0)` | Usually no action; value remains unlimited. |
-| `--json-rpc-debug.return-data-limit` | `uint(10485760)` | `int64(10485760)` | Usually no action; value is unchanged. |
-| `--log-level` | `info` | `""` | Pin explicitly if you require a specific log level. |
-| `--log-format` | `plain` | `""` | Pin explicitly if you require `plain` or `json`. |
+| Flag                                    | v1.19.0                | v1.20.0-beta            | Suggested validator action                                         |
+| --------------------------------------- | ---------------------- | ----------------------- | ------------------------------------------------------------------ |
+| `--minimum-gas-prices`                  | `""`                   | `160000000inj`          | Pin explicitly if you require a different minimum gas price.       |
+| `--pruning`                             | `default`              | `nothing`               | Pin `--pruning=default` if you do not want archive-style behavior. |
+| `--pruning-keep-recent`                 | `uint64(0)`            | string `"0"`            | Usually no action; type changed for config parsing.                |
+| `--pruning-interval`                    | `uint64(0)`            | string `"0"`            | Usually no action; type changed for config parsing.                |
+| `--iavl-cache-size`                     | `int(500000)`          | `uint64(781250)`        | Pin old value if memory/cache sizing depends on it.                |
+| `--api.enable`                          | `false` flag default   | `true` flag default     | Pin `--api.enable=false` if the REST API must remain disabled.     |
+| `--api.swagger`                         | `false` flag default   | `true` flag default     | Pin `--api.swagger=false` if Swagger must remain disabled.         |
+| `--api.address`                         | `tcp://localhost:1317` | `tcp://0.0.0.0:10337`   | Pin old address if exposing the API is not intended.               |
+| `--api.enabled-unsafe-cors`             | `false` flag default   | `true` flag default     | Pin `false` if CORS must remain disabled.                          |
+| `--json-rpc.api`                        | unset / nil            | `[eth, net, web3, inj]` | Pin explicitly if you require a different namespace set.           |
+| `--json-rpc-debug.api`                  | `[debug]`              | `[eth, debug, inj]`     | Pin explicitly if debug RPC is enabled and should stay debug-only. |
+| `--json-rpc.max-open-connections`       | `uint(0)`              | `int(0)`                | Usually no action; value remains unlimited.                        |
+| `--json-rpc.return-data-limit`          | `uint(512000)`         | `int64(512000)`         | Usually no action; value is unchanged.                             |
+| `--json-rpc-debug.max-open-connections` | `uint(0)`              | `int(0)`                | Usually no action; value remains unlimited.                        |
+| `--json-rpc-debug.return-data-limit`    | `uint(10485760)`       | `int64(10485760)`       | Usually no action; value is unchanged.                             |
+| `--log-level`                           | `info`                 | `""`                    | Pin explicitly if you require a specific log level.                |
+| `--log-format`                          | `plain`                | `""`                    | Pin explicitly if you require `plain` or `json`.                   |
 
-For `--api.*`, generated Injective `app.toml` defaults were already set to enabled in `v1.19.0`; the notable change is the effective CLI flag default used by `injectived start`.
+For `--api.*`, note that generated Injective `app.toml` defaults were already
+set to enabled in `v1.19.0`; the notable change is the effective CLI flag
+default used by `injectived start`.
+
+## Template Config Files
+
+### app.toml
+
+```toml
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+###############################################################################
+###                           Base Configuration                            ###
+###############################################################################
+
+# The minimum gas prices a validator is willing to accept for processing a
+# transaction. A transaction's fees must meet the minimum of any denomination
+# specified in this config (e.g. 0.25token1,0.0001token2).
+minimum-gas-prices = "160000000inj"
+
+# The maximum gas a query coming over rest/grpc may consume.
+# If this is set to zero, the query can consume an unbounded amount of gas.
+query-gas-limit = "0"
+
+# default: the last 362880 states are kept, pruning at 10 block intervals
+# nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
+# everything: 2 latest states will be kept; pruning at 10 block intervals.
+# custom: allow pruning options to be manually specified through 'pruning-keep-recent', and 'pruning-interval'
+pruning = "nothing"
+
+# These are applied if and only if the pruning strategy is custom.
+pruning-keep-recent = "0"
+pruning-interval = "0"
+
+# HaltHeight contains a non-zero block height at which a node will gracefully
+# halt and shutdown that can be used to assist upgrades and testing.
+#
+# Note: Commitment of state will be attempted on the corresponding block.
+halt-height = 0
+
+# HaltTime contains a non-zero minimum block time (in Unix seconds) at which
+# a node will gracefully halt and shutdown that can be used to assist upgrades
+# and testing.
+#
+# Note: Commitment of state will be attempted on the corresponding block.
+halt-time = 0
+
+# MinRetainBlocks defines the minimum block height offset from the current
+# block being committed, such that all blocks past this offset are pruned
+# from CometBFT. It is used as part of the process of determining the
+# ResponseCommit.RetainHeight value during ABCI Commit. A value of 0 indicates
+# that no blocks should be pruned.
+#
+# This configuration value is only responsible for pruning CometBFT blocks.
+# It has no bearing on application state pruning which is determined by the
+# "pruning-*" configurations.
+#
+# Note: CometBFT block pruning is dependant on this parameter in conjunction
+# with the unbonding (safety threshold) period, state pruning and state sync
+# snapshot parameters to determine the correct minimum value of
+# ResponseCommit.RetainHeight.
+min-retain-blocks = 0
+
+# InterBlockCache enables inter-block caching.
+inter-block-cache = true
+
+# IndexEvents defines the set of events in the form {eventType}.{attributeKey},
+# which informs CometBFT what to index. If empty, all events will be indexed.
+#
+# Example:
+# ["message.sender", "message.recipient"]
+index-events = []
+
+# IavlCacheSize set the size of the iavl tree cache (in number of nodes).
+iavl-cache-size = 781250
+
+# IAVLDisableFastNode enables or disables the fast node feature of IAVL.
+# Default is false.
+iavl-disable-fastnode = true
+
+# AppDBBackend defines the database backend type to use for the application and snapshots DBs.
+# An empty string indicates that a fallback will be used.
+# The fallback is the db_backend value set in CometBFT's config.toml.
+app-db-backend = ""
+
+###############################################################################
+###                           API Configuration                             ###
+###############################################################################
+
+[api]
+
+# Enable defines if the API server should be enabled.
+enable = true
+
+# Swagger defines if swagger documentation should automatically be registered.
+swagger = true
+
+# Address defines the API server to listen on.
+address = "tcp://0.0.0.0:10337"
+
+# MaxOpenConnections defines the number of maximum open connections.
+max-open-connections = 1000
+
+# RPCReadTimeout defines the CometBFT RPC read timeout (in seconds).
+rpc-read-timeout = 10
+
+# RPCWriteTimeout defines the CometBFT RPC write timeout (in seconds).
+rpc-write-timeout = 0
+
+# RPCMaxBodyBytes defines the CometBFT maximum request body (in bytes).
+rpc-max-body-bytes = 1000000
+
+# EnableUnsafeCORS defines if CORS should be enabled (unsafe - use it at your own risk).
+enabled-unsafe-cors = true
+
+###############################################################################
+###                           gRPC Configuration                            ###
+###############################################################################
+
+[grpc]
+
+# Enable defines if the gRPC server should be enabled.
+enable = true
+
+# Address defines the gRPC server address to bind to.
+address = "0.0.0.0:9900"
+
+# MaxRecvMsgSize defines the max message size in bytes the server can receive.
+# The default value is 10MB.
+max-recv-msg-size = "10485760"
+
+# MaxSendMsgSize defines the max message size in bytes the server can send.
+# The default value is math.MaxInt32.
+max-send-msg-size = "2147483647"
+
+###############################################################################
+###                        gRPC Web Configuration                           ###
+###############################################################################
+
+[grpc-web]
+
+# GRPCWebEnable defines if the gRPC-web should be enabled.
+# NOTE: gRPC must also be enabled, otherwise, this configuration is a no-op.
+# NOTE: gRPC-Web uses the same address as the API server.
+enable = true
+
+###############################################################################
+###                             EVM Configuration                           ###
+###############################################################################
+
+[evm]
+
+# Tracer defines the 'vm.Tracer' type that the EVM will use when the node is run in
+# debug mode. To enable tracing use the '--evm.tracer' flag when starting your node.
+# Valid types are: json|struct|access_list|markdown
+tracer = ""
+
+# MaxTxGasWanted defines the gas wanted for each eth tx returned in ante handler in check tx mode.
+max-tx-gas-wanted = 0
+
+# Enabled or disable TraceTx/TraceBlock/TraceCall gRPC endpoints
+enable-grpc-tracing = false
+
+###############################################################################
+###                           JSON RPC Configuration                        ###
+###############################################################################
+
+[json-rpc]
+
+# Enable defines if the gRPC server should be enabled.
+enable = true
+
+# Address defines the EVM RPC HTTP server address to bind to.
+address = "127.0.0.1:8545"
+
+# Address defines the EVM WebSocket server address to bind to.
+ws-address = "127.0.0.1:8546"
+
+# API defines a list of JSON-RPC namespaces that should be enabled
+# Example: "eth,txpool,personal,net,debug,web3"
+api = "eth,net,web3,inj"
+
+# GasCap sets a cap on gas that can be used in eth_call/estimateGas (0=infinite).
+gas-cap = 25000000
+
+# EVMTimeout is the global timeout for eth_call. Default: 5s.
+evm-timeout = "5s"
+
+# TxFeeCap is the global tx-fee cap for send transaction. Default: 1eth.
+txfee-cap = 1
+
+# FilterCap sets the global cap for total number of filters that can be created
+filter-cap = 200
+
+# FeeHistoryCap sets the global cap for total number of blocks that can be fetched
+feehistory-cap = 100
+
+# LogsCap defines the max number of results can be returned from single 'eth_getLogs' query.
+logs-cap = 10000
+
+# BlockRangeCap defines the max block range allowed for 'eth_getLogs' query.
+block-range-cap = 10000
+
+# HTTPTimeout is the read/write timeout of http json-rpc server.
+http-timeout = "30s"
+
+# HTTPIdleTimeout is the idle timeout of http json-rpc server.
+http-idle-timeout = "2m0s"
+
+# AllowUnprotectedTxs restricts unprotected (non EIP155 signed) transactions to be submitted via
+# the node's RPC when the global parameter is disabled.
+allow-unprotected-txs = false
+
+# MaxOpenConnections sets the maximum number of simultaneous connections
+# for the server listener.
+max-open-connections = 0
+
+# EnableIndexer enables the custom transaction indexer for the EVM (ethereum transactions).
+enable-indexer = true
+
+# AllowIndexerGap allow block gap for the custom transaction indexer for the EVM (ethereum transactions).
+allow-indexer-gap = true
+
+# Define if JSON-RPC metrics server should be enabled.
+metrics = true
+
+# MetricsAddress defines the EVM Metrics server address to bind to.
+# Prometheus metrics path: /debug/metrics/prometheus
+metrics-address = "127.0.0.1:6065"
+
+# Maximum number of bytes returned from eth_call or similar invocations.
+return-data-limit = 512000
+
+###############################################################################
+###                     Debug JSON RPC Configuration                        ###
+###############################################################################
+
+[json-rpc-debug]
+
+# Enable defines if the dedicated debug JSON-RPC server should be enabled.
+enable = false
+
+# Address defines the debug JSON-RPC HTTP server address to bind to.
+address = "127.0.0.1:8547"
+
+# API defines a list of JSON-RPC namespaces that should be enabled
+# Example: "eth,debug"
+api = "eth,debug,inj"
+
+# GasCap sets a cap on gas that can be used in eth_call/estimateGas (0=infinite).
+gas-cap = 250000000
+
+# EVMTimeout is the global timeout for eth_call. Default: 5s.
+evm-timeout = "20s"
+
+# TxFeeCap is the global tx-fee cap for send transaction. Default: 10eth.
+txfee-cap = 10
+
+# FilterCap sets the global cap for total number of filters that can be created
+filter-cap = 2000
+
+# FeeHistoryCap sets the global cap for total number of blocks that can be fetched
+feehistory-cap = 1000
+
+# LogsCap defines the max number of results can be returned from single 'eth_getLogs' query.
+logs-cap = 100000
+
+# BlockRangeCap defines the max block range allowed for 'eth_getLogs' query.
+block-range-cap = 50000
+
+# HTTPTimeout is the read/write timeout of http json-rpc server.
+http-timeout = "30s"
+
+# HTTPIdleTimeout is the idle timeout of http json-rpc server.
+http-idle-timeout = "2m0s"
+
+# MaxOpenConnections sets the maximum number of simultaneous connections
+# for the server listener.
+max-open-connections = 0
+
+# Maximum number of bytes returned from eth_call or similar invocations.
+return-data-limit = 10485760
+
+###############################################################################
+###                  Injective Websocket Configuration                      ###
+###############################################################################
+
+[injective-websocket]
+
+# Address defines the websocket server address to bind to.
+address = ""
+
+# MaxOpenConnections sets the maximum number of simultaneous connections.
+max-open-connections = 0
+
+# ReadTimeout defines the HTTP read timeout.
+read-timeout = "10s"
+
+# WriteTimeout defines the HTTP write timeout.
+write-timeout = "10s"
+
+# MaxBodyBytes defines the maximum allowed HTTP body size (in bytes).
+max-body-bytes = 1000000
+
+# MaxHeaderBytes defines the maximum allowed HTTP header size (in bytes).
+max-header-bytes = 1048576
+
+# MaxRequestBatchSize defines the maximum number of RPC calls per batch request.
+max-request-batch-size = 10
+
+###############################################################################
+###                        State Sync Configuration                         ###
+###############################################################################
+
+# State sync snapshots allow other nodes to rapidly join the network without replaying historical
+# blocks, instead downloading and applying a snapshot of the application state at a given height.
+[state-sync]
+
+# snapshot-interval specifies the block interval at which local state sync snapshots are
+# taken (0 to disable).
+snapshot-interval = 0
+
+# snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
+snapshot-keep-recent = 2
+
+###############################################################################
+###                              State Streaming                            ###
+###############################################################################
+
+# Streaming allows nodes to stream state to external systems.
+[streaming]
+
+# streaming.abci specifies the configuration for the ABCI Listener streaming service.
+[streaming.abci]
+
+# List of kv store keys to stream out via gRPC.
+# The store key names MUST match the module's StoreKey name.
+#
+# Example:
+# ["acc", "bank", "gov", "staking", "mint"[,...]]
+# ["*"] to expose all keys.
+keys = []
+
+# The plugin name used for streaming via gRPC.
+# Streaming is only enabled if this is set.
+# Supported plugins: abci
+plugin = ""
+
+# stop-node-on-err specifies whether to stop the node on message delivery error.
+stop-node-on-err = true
+
+###############################################################################
+###                         Mempool                                         ###
+###############################################################################
+
+[mempool]
+# Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
+# Setting max_txs to negative 1 (-1) will disable transactions from being inserted into the mempool (no-op mempool).
+# Setting max_txs to a positive number (> 0) will limit the number of transactions in the mempool, by the specified amount.
+#
+# Note, this configuration only applies to SDK built-in app-side mempool
+# implementations.
+max-txs = -1
+
+###############################################################################
+###                         ChainStream Server                              ###
+###############################################################################
+
+[chainstream]
+
+# ChainStream server address to bind to. Empty = disabled.
+server = ""
+
+# Configure ChainStream server buffer capacity for each connected client
+buffer-cap = "100"
+
+# Configure ChainStream publisher buffer capacity
+publisher-buffer-cap = "100"
+
+# Define if Keepalive configuration params should be applied to chainstream gRPC server
+enforce-keepalive = "false"
+
+# Amount of time (in seconds) a client should wait before sending a keepalive ping
+min-client-ping-interval = "30"
+
+# Amount of time in seconds a connection is allowed to stay idle before forcing the disconnection
+max-connection-idle = "180"
+
+# Amount of time in seconds after which the server will send a keepalive ping to the client on an idle connection
+server-ping-interval = "60"
+
+# Amount of time in seconds the server waits for the client to respond to a ping message before forcing a disconnection
+server-ping-response-timeout = "40"
+
+###############################################################################
+###                         Metrics Configuration                         ###
+###############################################################################
+
+[metrics]
+
+# whether metrics collections should be enabled, default: false
+metrics-enabled = false
+
+# whether tracing should be enabled, default: false
+tracing-enabled = false
+
+# gRPC OTEL receiver endpoint, default: localhost:4317
+endpoint = "localhost:4317"
+
+# whether to use TLS during Endpoint connection
+insecure-endpoint = false
+
+# time interval between metric exports, default: 10s
+export-interval = "10s"
+
+# timeout before FuncTiming marks the function as stuck and ends the span.
+# Set to 0 (default) to disable timeouts completely.
+stuck-func-timeout = "0s"
+
+# time after which block is considered slow and flight recorder should dump the profile to disk.
+# 0 - disables flight recorder.
+flight-recorder-threshold = "0s"
+```
+
+### config.toml
+
+```toml
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+# NOTE: Any path below can be absolute (e.g. "/var/myawesomeapp/data") or
+# relative to the home directory (e.g. "data"). The home directory is
+# "$HOME/.cometbft" by default, but could be changed via $CMTHOME env variable
+# or --home cmd flag.
+
+# The version of the CometBFT binary that created or
+# last modified the config file. Do not modify this.
+version = "1.0.1"
+
+#######################################################################
+###                   Main Base Config Options                      ###
+#######################################################################
+
+# TCP or UNIX socket address of the ABCI application,
+# or the name of an ABCI application compiled in with the CometBFT binary
+proxy_app = "tcp://0.0.0.0:26658"
+
+# A custom human readable name for this node
+moniker = "validatornode"
+
+# Database backend: badgerdb | goleveldb | pebbledb | rocksdb | cleveldb | boltdb
+# * badgerdb (uses github.com/dgraph-io/badger)
+#   - stable
+#   - pure go
+#   - use badgerdb build tag (go build -tags badgerdb)
+# * goleveldb (github.com/syndtr/goleveldb)
+#   - UNMAINTAINED
+#   - stable
+#   - pure go
+# * pebbledb (uses github.com/cockroachdb/pebble)
+#   - stable
+#   - pure go
+# * rocksdb (uses github.com/linxGnu/grocksdb)
+#   - requires gcc
+#   - use rocksdb build tag (go build -tags rocksdb)
+# * cleveldb (uses levigo wrapper)
+#   - DEPRECATED
+#   - requires gcc
+#   - use cleveldb build tag (go build -tags cleveldb)
+# * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
+#   - DEPRECATED
+#   - stable
+#   - use boltdb build tag (go build -tags boltdb)
+db_backend = "goleveldb"
+
+# Database directory
+db_dir = "data"
+
+# Output level for logging, including package level options
+log_level = "info"
+
+# Output format: 'plain' (colored text) or 'json'
+log_format = "plain"
+
+##### additional base config options #####
+
+# Path to the JSON file containing the initial validator set and other meta data
+genesis_file = "config/genesis.json"
+
+# Path to the JSON file containing the private key to use as a validator in the consensus protocol
+priv_validator_key_file = "config/priv_validator_key.json"
+
+# Path to the JSON file containing the last sign state of a validator
+priv_validator_state_file = "data/priv_validator_state.json"
+
+# TCP or UNIX socket address for CometBFT to listen on for
+# connections from an external PrivValidator process
+priv_validator_laddr = "tcp://0.0.0.0:26658"
+
+# Path to the JSON file containing the private key to use for node authentication in the p2p protocol
+node_key_file = "config/node_key.json"
+
+# Mechanism to connect to the ABCI application: socket | grpc
+abci = "socket"
+
+# If true, query the ABCI app on connecting to a new peer
+# so the app can decide if we should keep the connection or not
+filter_peers = false
+
+
+#######################################################################
+###                 Advanced Configuration Options                  ###
+#######################################################################
+
+#######################################################
+###       RPC Server Configuration Options          ###
+#######################################################
+[rpc]
+
+# TCP or UNIX socket address for the RPC server to listen on
+laddr = "tcp://0.0.0.0:26657"
+
+# A list of origins a cross-domain request can be executed from
+# Default value '[]' disables cors support
+# Use '["*"]' to allow any origin
+cors_allowed_origins = []
+
+# A list of methods the client is allowed to use with cross-domain requests
+cors_allowed_methods = ["HEAD", "GET", "POST", ]
+
+# A list of non simple headers the client is allowed to use with cross-domain requests
+cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time", ]
+
+# Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
+unsafe = false
+
+# Maximum number of simultaneous connections (including WebSocket).
+# If you want to accept a larger number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+# Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
+# 1024 - 40 - 10 - 50 = 924 = ~900
+max_open_connections = 900
+
+# Maximum number of unique clientIDs that can /subscribe.
+# If you're using /broadcast_tx_commit, set to the estimated maximum number
+# of broadcast_tx_commit calls per block.
+max_subscription_clients = 100
+
+# Maximum number of unique queries a given client can /subscribe to.
+# If you're using /broadcast_tx_commit, set to the estimated maximum number
+# of broadcast_tx_commit calls per block.
+max_subscriptions_per_client = 5
+
+# Experimental parameter to specify the maximum number of events a node will
+# buffer, per subscription, before returning an error and closing the
+# subscription. Must be set to at least 100, but higher values will accommodate
+# higher event throughput rates (and will use more memory).
+experimental_subscription_buffer_size = 200
+
+# Experimental parameter to specify the maximum number of RPC responses that
+# can be buffered per WebSocket client. If clients cannot read from the
+# WebSocket endpoint fast enough, they will be disconnected, so increasing this
+# parameter may reduce the chances of them being disconnected (but will cause
+# the node to use more memory).
+#
+# Must be at least the same as "experimental_subscription_buffer_size",
+# otherwise connections could be dropped unnecessarily. This value should
+# ideally be somewhat higher than "experimental_subscription_buffer_size" to
+# accommodate non-subscription-related RPC responses.
+experimental_websocket_write_buffer_size = 200
+
+# If a WebSocket client cannot read fast enough, at present we may
+# silently drop events instead of generating an error or disconnecting the
+# client.
+#
+# Enabling this experimental parameter will cause the WebSocket connection to
+# be closed instead if it cannot read fast enough, allowing for greater
+# predictability in subscription behavior.
+experimental_close_on_slow_client = false
+
+# How long to wait for a tx to be committed during /broadcast_tx_commit.
+# WARNING: Using a value larger than 10s will result in increasing the
+# global HTTP write timeout, which applies to all connections and endpoints.
+# See https://github.com/tendermint/tendermint/issues/3435
+timeout_broadcast_tx_commit = "10s"
+
+# Maximum number of requests that can be sent in a batch
+# If the value is set to '0' (zero-value), then no maximum batch size will be
+# enforced for a JSON-RPC batch request.
+max_request_batch_size = 10
+
+# Maximum size of request body, in bytes
+max_body_bytes = 1000000
+
+# Maximum size of request header, in bytes
+max_header_bytes = 1048576
+
+# The path to a file containing certificate that is used to create the HTTPS server.
+# Might be either absolute path or path related to CometBFT's config directory.
+# If the certificate is signed by a certificate authority,
+# the certFile should be the concatenation of the server's certificate, any intermediates,
+# and the CA's certificate.
+# NOTE: both tls_cert_file and tls_key_file must be present for CometBFT to create HTTPS server.
+# Otherwise, HTTP server is run.
+tls_cert_file = ""
+
+# The path to a file containing matching private key that is used to create the HTTPS server.
+# Might be either absolute path or path related to CometBFT's config directory.
+# NOTE: both tls_cert_file and tls_key_file must be present for CometBFT to create HTTPS server.
+# Otherwise, HTTP server is run.
+tls_key_file = ""
+
+# pprof listen address (https://golang.org/pkg/net/http/pprof)
+pprof_laddr = "localhost:6060"
+
+#######################################################
+###       gRPC Server Configuration Options         ###
+#######################################################
+
+#
+# Note that the gRPC server is exposed unauthenticated. It is critical that
+# this server not be exposed directly to the public internet. If this service
+# must be accessed via the public internet, please ensure that appropriate
+# precautions are taken (e.g. fronting with a reverse proxy like nginx with TLS
+# termination and authentication, using DDoS protection services like
+# CloudFlare, etc.).
+#
+
+[grpc]
+
+# TCP or UNIX socket address for the RPC server to listen on. If not specified,
+# the gRPC server will be disabled.
+laddr = ""
+
+#
+# Each gRPC service can be turned on/off, and in some cases configured,
+# individually. If the gRPC server is not enabled, all individual services'
+# configurations are ignored.
+#
+
+# The gRPC version service provides version information about the node and the
+# protocols it uses.
+[grpc.version_service]
+enabled = true
+
+# The gRPC block service returns block information
+[grpc.block_service]
+enabled = true
+
+# The gRPC block results service returns block results for a given height. If no height
+# is given, it will return the block results from the latest height.
+[grpc.block_results_service]
+enabled = true
+
+#
+# Configuration for privileged gRPC endpoints, which should **never** be exposed
+# to the public internet.
+#
+[grpc.privileged]
+# The host/port on which to expose privileged gRPC endpoints.
+laddr = ""
+
+#
+# Configuration specifically for the gRPC pruning service, which is considered a
+# privileged service.
+#
+[grpc.privileged.pruning_service]
+
+# Only controls whether the pruning service is accessible via the gRPC API - not
+# whether a previously set pruning service retain height is honored by the
+# node. See the [storage.pruning] section for control over pruning.
+#
+# Disabled by default.
+enabled = false
+
+#######################################################
+###           P2P Configuration Options             ###
+#######################################################
+[p2p]
+
+# Address to listen for incoming connections
+laddr = "tcp://0.0.0.0:26656"
+
+# Address to advertise to peers for them to dial. If empty, will use the same
+# port as the laddr, and will introspect on the listener to figure out the
+# address. IP and port are required. Example: 159.89.10.97:26656
+external_address = ""
+
+# Comma separated list of seed nodes to connect to
+seeds = "38c18461209694e1f667ff2c8636ba827cc01c86@176.9.143.252:11751,4f9025feca44211eddc26cd983372114947b2e85@176.9.140.49:11751,c98bb1b889ddb58b46e4ad3726c1382d37cd5609@65.109.51.80:11751,23d0eea9bb42316ff5ea2f8b4cd8475ef3f35209@65.109.36.70:11751,f9ae40fb4a37b63bea573cc0509b4a63baa1a37a@15.235.114.80:11751,7f3473ddab10322b63789acb4ac58647929111ba@15.235.13.116:11751,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:14356,ebc272824924ea1a27ea3183dd0b9ba713494f83@injective.mainnet.seed.autostake.net:26726,1846e76e14913124a07e231586d487a0636c0296@tenderseed.ccvalidators.com:26007"
+
+# Comma separated list of nodes to keep persistent connections to
+persistent_peers = ""
+
+# Path to address book
+addr_book_file = "config/addrbook.json"
+
+# Set true for strict address routability rules
+# Set false for private or local networks
+addr_book_strict = true
+
+# Maximum number of inbound peers
+max_num_inbound_peers = 40
+
+# Maximum number of outbound peers to connect to, excluding persistent peers
+max_num_outbound_peers = 40
+
+# List of node IDs, to which a connection will be (re)established ignoring any existing limits
+unconditional_peer_ids = ""
+
+# Maximum pause when redialing a persistent peer (if zero, exponential backoff is used)
+persistent_peers_max_dial_period = "0s"
+
+# Time to wait before flushing messages out on the connection
+flush_throttle_timeout = "10ms"
+
+# Maximum size of a message packet payload, in bytes
+max_packet_msg_payload_size = 1024
+
+# Rate at which packets can be sent, in bytes/second
+send_rate = 5120000
+
+# Rate at which packets can be received, in bytes/second
+recv_rate = 5120000
+
+# Set true to enable the peer-exchange reactor
+pex = true
+
+# Seed mode, in which node constantly crawls the network and looks for
+# peers. If another node asks it for addresses, it responds and disconnects.
+#
+# Does not work if the peer-exchange reactor is disabled.
+seed_mode = false
+
+# Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
+private_peer_ids = ""
+
+# Toggle to disable guard against peers connecting from the same ip.
+allow_duplicate_ip = false
+
+# Peer connection configuration.
+handshake_timeout = "20s"
+dial_timeout = "3s"
+
+#######################################################
+###          Mempool Configuration Options          ###
+#######################################################
+[mempool]
+
+# The type of mempool for this node to use.
+#
+#  Possible types:
+#  - "flood" : concurrent linked list mempool with flooding gossip protocol
+#  (default)
+#  - "nop"   : nop-mempool (short for no operation; the ABCI app is responsible
+#  for storing, disseminating and proposing txs). "create_empty_blocks=false" is
+#  not supported.
+type = "flood"
+
+# recheck (default: true) defines whether CometBFT should recheck the
+# validity for all remaining transaction in the mempool after a block.
+# Since a block affects the application state, some transactions in the
+# mempool may become invalid. If this does not apply to your application,
+# you can disable rechecking.
+recheck = true
+
+# recheck_timeout is the time the application has during the rechecking process
+# to return CheckTx responses, once all requests have been sent. Responses that
+# arrive after the timeout expires are discarded. It only applies to
+# non-local ABCI clients and when recheck is enabled.
+recheck_timeout = "1s"
+
+# broadcast (default: true) defines whether the mempool should relay
+# transactions to other peers. Setting this to false will stop the mempool
+# from relaying transactions to other peers until they are included in a
+# block. In other words, if Broadcast is disabled, only the peer you send
+# the tx to will see it until it is included in a block.
+broadcast = true
+
+# wal_dir (default: "") configures the location of the Write Ahead Log
+# (WAL) for the mempool. The WAL is disabled by default. To enable, set
+# wal_dir to where you want the WAL to be written (e.g.
+# "data/mempool.wal").
+wal_dir = ""
+
+# Maximum number of transactions in the mempool
+size = 200
+
+# Maximum size in bytes of a single transaction accepted into the mempool.
+max_tx_bytes = 1048576
+
+# The maximum size in bytes of all transactions stored in the mempool.
+# This is the raw, total transaction size. For example, given 1MB
+# transactions and a 5MB maximum mempool byte size, the mempool will
+# only accept five transactions.
+max_txs_bytes = 67108864
+
+# Size of the cache (used to filter transactions we saw earlier) in transactions
+cache_size = 10000
+
+# Do not remove invalid transactions from the cache (default: false)
+# Set to true if it's not possible for any invalid transaction to become valid
+# again in the future.
+keep-invalid-txs-in-cache = false
+
+# Experimental parameters to limit gossiping txs to up to the specified number of peers.
+# We use two independent upper values for persistent and non-persistent peers.
+# Unconditional peers are not affected by this feature.
+# If we are connected to more than the specified number of persistent peers, only send txs to
+# ExperimentalMaxGossipConnectionsToPersistentPeers of them. If one of those
+# persistent peers disconnects, activate another persistent peer.
+# Similarly for non-persistent peers, with an upper limit of
+# ExperimentalMaxGossipConnectionsToNonPersistentPeers.
+# If set to 0, the feature is disabled for the corresponding group of peers, that is, the
+# number of active connections to that group of peers is not bounded.
+# For non-persistent peers, if enabled, a value of 10 is recommended based on experimental
+# performance results using the default P2P configuration.
+experimental_max_gossip_connections_to_persistent_peers = 0
+experimental_max_gossip_connections_to_non_persistent_peers = 0
+
+# When using the Flood mempool type, enable the DOG gossip protocol to
+# reduce network bandwidth on transaction dissemination (for details, see
+# specs/mempool/gossip/).
+dog_protocol_enabled = true
+
+# Used by the DOG protocol to set the desired transaction redundancy level
+# for the node. For example, redundancy of 0.5 means that, for every two first-time
+# transactions received, the node will receive one duplicate transaction.
+dog_target_redundancy = 1
+
+# Used by the DOG protocol to set how often it will attempt to adjust the
+# redundancy level. The higher the value, the longer it will take the node
+# to reduce bandwidth and converge to a stable redundancy level.
+dog_adjust_interval = "1s"
+
+#######################################################
+###         State Sync Configuration Options        ###
+#######################################################
+[statesync]
+# State sync rapidly bootstraps a new node by discovering, fetching, and restoring a state machine
+# snapshot from peers instead of fetching and replaying historical blocks. Requires some peers in
+# the network to take and serve state machine snapshots. State sync is not attempted if the node
+# has any local state (LastBlockHeight > 0). The node will have a truncated block history,
+# starting from the height of the snapshot.
+enable = false
+
+# RPC servers (comma-separated) for light client verification of the synced state machine and
+# retrieval of state data for node bootstrapping. Also needs a trusted height and corresponding
+# header hash obtained from a trusted source, and a period during which validators can be trusted.
+#
+# For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
+# weeks) during which they can be financially punished (slashed) for misbehavior.
+rpc_servers = ""
+trust_height = 0
+trust_hash = ""
+trust_period = "168h0m0s"
+
+# Time to spend discovering snapshots before initiating a restore.
+discovery_time = "15s"
+
+# Temporary directory for state sync snapshot chunks, defaults to the OS tempdir (typically /tmp).
+# Will create a new, randomly named directory within, and remove it when done.
+temp_dir = ""
+
+# The timeout duration before re-requesting a chunk, possibly from a different
+# peer (default: 1 minute).
+chunk_request_timeout = "10s"
+
+# The number of concurrent chunk fetchers to run (default: 1).
+chunk_fetchers = "4"
+
+#######################################################
+###       Block Sync Configuration Options          ###
+#######################################################
+[blocksync]
+
+# Block Sync version to use:
+#
+# In v0.37, v1 and v2 of the block sync protocols were deprecated.
+# Please use v0 instead.
+#
+#   1) "v0" - the default block sync implementation
+version = "v0"
+
+#######################################################
+###         Consensus Configuration Options         ###
+#######################################################
+[consensus]
+
+wal_file = "data/cs.wal/wal"
+
+# How long we wait for a proposal block before prevoting nil
+timeout_propose = "3s"
+# How much timeout_propose increases with each round
+timeout_propose_delta = "500ms"
+# How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
+timeout_prevote = "1s"
+# How much the timeout_prevote increases with each round
+timeout_prevote_delta = "500ms"
+# How long we wait after receiving +2/3 precommits for “anything” (ie. not a single block or nil)
+timeout_precommit = "1s"
+# How much the timeout_precommit increases with each round
+timeout_precommit_delta = "500ms"
+# How long we wait after committing a block, before starting on the new
+# height (this gives us a chance to receive some more precommits, even
+# though we already have +2/3).
+# Set to 0 if you want to make progress as soon as the node has all the precommits.
+timeout_commit = "500ms"
+
+# Deprecated: set `timeout_commit` to 0 instead.
+skip_timeout_commit = false
+
+# How many blocks to look back to check existence of the node's consensus votes before joining consensus
+# When non-zero, the node will panic upon restart
+# if the same consensus key was used to sign {double_sign_check_height} last blocks.
+# So, validators should stop the state machine, wait for some blocks, and then restart the state machine to avoid panic.
+double_sign_check_height = 0
+
+# EmptyBlocks mode and possible interval between empty blocks
+create_empty_blocks = true
+create_empty_blocks_interval = "0s"
+
+# Reactor sleep duration parameters
+peer_gossip_sleep_duration = "10ms"
+peer_gossip_intraloop_sleep_duration = "0s"
+peer_query_maj23_sleep_duration = "2s"
+
+#######################################################
+###         Storage Configuration Options           ###
+#######################################################
+[storage]
+
+# Set to true to discard ABCI responses from the state store, which can save a
+# considerable amount of disk space. Set to false to ensure ABCI responses are
+# persisted. ABCI responses are required for /block_results RPC queries, and to
+# reindex events in the command-line tool.
+discard_abci_responses = false
+
+# The representation of keys in the database.
+# The current representation of keys in Comet's stores is considered to be v1
+# Users can experiment with a different layout by setting this field to v2.
+# Note that this is an experimental feature and switching back from v2 to v1
+# is not supported by CometBFT.
+# If the database was initially created with v1, it is necessary to migrate the DB
+# before switching to v2. The migration is not done automatically.
+# v1 - the legacy layout existing in Comet prior to v1.
+# v2 - Order preserving representation ordering entries by height.
+experimental_db_key_layout = "v1"
+
+# If set to true, CometBFT will force compaction to happen for databases that support this feature.
+# and save on storage space. Setting this to true is most benefits when used in combination
+# with pruning as it will physically delete the entries marked for deletion.
+# false by default (forcing compaction is disabled).
+compact = false
+
+# To avoid forcing compaction every time, this parameter instructs CometBFT to wait
+# the given amount of blocks to be pruned before triggering compaction.
+# It should be tuned depending on the number of items. If your retain height is 1 block,
+# it is too much of an overhead to try compaction every block. But it should also not be a very
+# large multiple of your retain height as it might occur bigger overheads.
+compaction_interval = "1000"
+
+[storage.pruning]
+
+# The time period between automated background pruning operations.
+interval = "10s"
+
+#
+# Storage pruning configuration relating only to the data companion.
+#
+[storage.pruning.data_companion]
+
+# Whether automatic pruning respects values set by the data companion. Disabled
+# by default. All other parameters in this section are ignored when this is
+# disabled.
+#
+# If disabled, only the application retain height will influence block pruning
+# (but not block results pruning). Only enabling this at a later stage will
+# potentially mean that blocks below the application-set retain height at the
+# time will not be available to the data companion.
+enabled = false
+
+# The initial value for the data companion block retain height if the data
+# companion has not yet explicitly set one. If the data companion has already
+# set a block retain height, this is ignored.
+initial_block_retain_height = 0
+
+# The initial value for the data companion block results retain height if the
+# data companion has not yet explicitly set one. If the data companion has
+# already set a block results retain height, this is ignored.
+initial_block_results_retain_height = 0
+
+#######################################################
+###   Transaction Indexer Configuration Options     ###
+#######################################################
+[tx_index]
+
+# What indexer to use for transactions
+#
+# The application will set which txs to index. In some cases a node operator will be able
+# to decide which txs to index based on configuration set in the application.
+#
+# Options:
+#   1) "null"
+#   2) "kv" (default) - the simplest possible indexer, backed by key-value storage (defaults to levelDB; see DBBackend).
+# 		- When "kv" is chosen "tx.height" and "tx.hash" will always be indexed.
+#   3) "psql" - the indexer services backed by PostgreSQL.
+# When "kv" or "psql" is chosen "tx.height" and "tx.hash" will always be indexed.
+indexer = "kv"
+
+# The PostgreSQL connection configuration, the connection format:
+#   postgresql://<user>:<password>@<host>:<port>/<db>?<opts>
+psql-conn = ""
+
+#######################################################
+###       Instrumentation Configuration Options     ###
+#######################################################
+[instrumentation]
+
+# When true, Prometheus metrics are served under /metrics on
+# PrometheusListenAddr.
+# Check out the documentation for the list of available metrics.
+prometheus = true
+
+# Address to listen for Prometheus collector(s) connections
+prometheus_listen_addr = "127.0.0.1:26660"
+
+# Maximum number of simultaneous connections.
+# If you want to accept a larger number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+max_open_connections = 3
+
+# Instrumentation namespace
+namespace = "cometbft"
+```

--- a/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
+++ b/.gitbook/infra/validator-mainnet/validator-v1.20-flag-changes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Validator Startup Flag Changes for v1.20.0-beta
+title: Validator Startup Flag Changes for v1.20.0
 updatedAt: "2026-06-02"
 ---
 
@@ -34,7 +34,7 @@ for the `v1.20.0` tag can be found at the bottom of this file.
 
 Update any startup configuration that still uses the old flag names.
 
-| v1.19.0 flag                                    | v1.20.0-beta flag                               | Notes                                                |
+| v1.19.0 flag                                    | v1.20.0 flag                               | Notes                                                |
 | ----------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------- |
 | `--metrics-enable-metrics=false`                | `--metrics.metrics-enabled=false`               | Same default.                                        |
 | `--metrics-enable-tracing=false`                | `--metrics.tracing-enabled=false`               | Same default.                                        |
@@ -57,7 +57,7 @@ Update any startup configuration that still uses the old flag names.
 
 These flags did not exist as `injectived start` flags in `v1.19.0`.
 
-| v1.20.0-beta flag                              | Default       | Notes                                                                     |
+| v1.20.0 flag                              | Default       | Notes                                                                     |
 | ---------------------------------------------- | ------------- | ------------------------------------------------------------------------- |
 | `--app-db-backend`                             | `""`          | Empty value falls back to the CometBFT DB backend.                        |
 | `--index-events`                               | `[]`          | Controls event indexing for CometBFT. Empty means all events are indexed. |
@@ -87,7 +87,7 @@ Remove these from startup scripts before running `v1.20.0`.
 
 If your deployment relied on the old default, set the old value explicitly.
 
-| Flag                                    | v1.19.0                | v1.20.0-beta            | Suggested validator action                                         |
+| Flag                                    | v1.19.0                | v1.20.0            | Suggested validator action                                         |
 | --------------------------------------- | ---------------------- | ----------------------- | ------------------------------------------------------------------ |
 | `--minimum-gas-prices`                  | `""`                   | `160000000inj`          | Pin explicitly if you require a different minimum gas price.       |
 | `--pruning`                             | `default`              | `nothing`               | Pin `--pruning=default` if you do not want archive-style behavior. |


### PR DESCRIPTION
## Summary

- Add a validator-facing page for `injectived start` flag changes between v1.19.0 and v1.20.0.
- Register the page in Mainnet Validator navigation next to the v1.20.0 upgrade guide.
- Link the v1.20.0 upgrade guide to the flag migration page before the restart step.

## Validation

- `git diff --check`
- `docs.json` parsed successfully with Node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v1.20.0 validator upgrade guide directing validators to review startup flag changes before restarting
  * Added comprehensive guide documenting validator flag changes, including renamed, added, and removed flags from v1.19.0 to v1.20.0
  * Included configuration templates with updated defaults for the upgrade

<!-- end of auto-generated comment: release notes by coderabbit.ai -->