### PR TITLE
changed reference to validator

### DIFF
--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0-flag-changes.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0-flag-changes.mdx
@@ -1,10 +1,10 @@
 ---
-title: Validator Startup Flag Changes for v1.20.0
+title: Injectived Startup Flag Changes for v1.20.0
 updatedAt: "2026-06-02"
 ---
 
 This note summarizes `injectived start` flag changes between `v1.19.0` and
-`v1.20.0`. Validators should review their startup scripts, Helm charts,
+`v1.20.0`. All node runners should review their startup scripts, Helm charts,
 systemd units, or Kubernetes manifests before upgrading.
 
 ## Recommended Upgrade Checklist

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.0.mdx
@@ -56,7 +56,7 @@ rm -rf .injectived/wasm/wasm/cache/
 
 ## Breaking Changes MUST REVIEW
 
-Review the [v1.20.0 validator startup flag changes](./validator-v1.20-flag-changes/) before restarting `injectived`. Deprecated flags must be removed, renamed flags should be updated, and changed defaults should be pinned explicitly if your node depends on the previous behavior.
+Review the [v1.20.0 injectived startup flag changes](./canonical-chain-upgrade-v1.20.0-flag-changes/) before restarting `injectived`. Deprecated flags must be removed, renamed flags should be updated, and changed defaults should be pinned explicitly if your node depends on the previous behavior.
 
 ### Steps
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v1.20.0 canonical chain upgrade documentation to reference chain-specific startup flag changes.
  * Improved documentation links to direct users to correct upgrade procedures.
  * Enhanced clarity for startup flag configuration guidance during v1.20.0 network deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->