### PR TITLE
docs: update link to x402 demo

### DIFF
--- a/.gitbook/developers-ai/x402.mdx
+++ b/.gitbook/developers-ai/x402.mdx
@@ -36,7 +36,7 @@ You will also need:
 
 ## Getting started
 
-Open the x402 demo at [`agents.injective.com/x402-v5`](https://agents.injective.com/x402-v5) in your browser.
+Open the x402 demo at [`agents.injective.com/x402`](https://agents.injective.com/x402) in your browser.
 
 ![x402 demo start](/img/x402-demo-start.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,330 @@
+{
+  "name": "injective-docs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "injective-docs",
+      "version": "0.0.0",
+      "dependencies": {
+        "dotenv": "16.4.5"
+      },
+      "devDependencies": {
+        "gitbook-parsers": "0.8.9"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/asciidoctor.js": {
+      "version": "1.5.3-preview.1",
+      "resolved": "https://registry.npmjs.org/asciidoctor.js/-/asciidoctor.js-1.5.3-preview.1.tgz",
+      "integrity": "sha512-i/iUuRCy+lZQwPL03a7CiJLRKil79t+/rezOC/vzuLb6ciWn+5QjhBSvUqosEzeebBGemJ3kzd5EvpRbNSD58Q==",
+      "deprecated": "Package no longer supported. Replaced by @asciidoctor/core",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "opal-npm-wrapper": "^0.1.1",
+        "xmlhttprequest": "~1.6.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+      "integrity": "sha512-Fwcm3zkR37STnPC8FepSHeSYJM5Rd596TZOcfDUdojR4Q735aK1Xn+M+ISagNneuCwMjK28w4kX+ETILGNT/UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "~1.0.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.8.1",
+        "lodash": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+      "integrity": "sha512-/xPlD7betkfd7ChGkLGGWx5HWyiHDOSn7aACLzdH0nwucPvB0EAm8hMBm7Xn7vGfAeRRN7KZ8wumGm8NoNcMRw==",
+      "dev": true,
+      "license": "BSD-like",
+      "dependencies": {
+        "boolbase": "~1.0.0",
+        "css-what": "1.0",
+        "domutils": "1.4",
+        "nth-check": "~1.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+      "integrity": "sha512-60SUMPBreXrLXgvpM8kYpO0AOyMRhdRlXFX5BMQbZq1SIJCyNE56nqFQhmvREQdUJpedbGRYZ5wOyq3/F6q5Zw==",
+      "dev": true,
+      "license": "BSD-like",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+      "integrity": "sha512-ZkVgS/PpxjyJMb+S2iVHHEZjVnOUtjGp0/zstqKGTE9lrZtNHlNQmLwP/lhLMEApYbzc08BKMx9IFpKhaSbW1w==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/gitbook-asciidoc": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/gitbook-asciidoc/-/gitbook-asciidoc-0.2.4.tgz",
+      "integrity": "sha512-z2uyH3lTbWs9IxEB3h2npvDbv9qSbS9L9W5RYHs3xnNYPB0j/0Z14pfyxWMMkzGpknL704CSPEOEs2vWMk/FYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "asciidoctor.js": "1.5.3-preview.1",
+        "cheerio": "^0.19.0",
+        "lodash": "^3.2.0",
+        "q": "^1.1.2"
+      }
+    },
+    "node_modules/gitbook-markdown": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/gitbook-markdown/-/gitbook-markdown-0.5.3.tgz",
+      "integrity": "sha512-7TmKPsXc2XAJ1A6PfNjzVIbmBYJp8rUo823u9GA0LUh7DrspDnUzju98kojGSCdVQ9j4llD11jqdj1XnnYHzXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "kramed": "0.5.5",
+        "kramed-text-renderer": "0.2.1",
+        "lodash": "^3.2.0"
+      }
+    },
+    "node_modules/gitbook-parsers": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/gitbook-parsers/-/gitbook-parsers-0.8.9.tgz",
+      "integrity": "sha512-WU9VbgTcZXi++2UHR66zO/zas07ek3FGGvVZOqMGHoXmcMqGRgNUv5+pca0nKw1Kn1IVLyx+NkvrGgwvq8Bh9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gitbook-asciidoc": "0.2.4",
+        "gitbook-markdown": "0.5.3",
+        "gitbook-restructuredtext": "0.2.3",
+        "lodash": "^3.2.0",
+        "q": "^1.1.2"
+      }
+    },
+    "node_modules/gitbook-restructuredtext": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/gitbook-restructuredtext/-/gitbook-restructuredtext-0.2.3.tgz",
+      "integrity": "sha512-9dnVW14h2NTYAFIdpwUpMAEs4P84hNfRD1W5ZILyNZenLgofzCXB0mLVrgvoX6/3x8B223ljThyB1ZKBfGABfQ==",
+      "dev": true,
+      "license": "Apache 2",
+      "dependencies": {
+        "cheerio": "^0.19.0",
+        "lodash": "^3.2.0",
+        "q": "^1.1.2",
+        "tmp": "0.0.24"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
+      "dev": true,
+      "license": "BSD-like"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kramed": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/kramed/-/kramed-0.5.5.tgz",
+      "integrity": "sha512-3AAP6c6CdbCtXyaZ9Jyj0k4Hf7q11JL+6DT3Mt6oOr0h0INrD01WeiqgdRJZm1UWMHdyGU/WjNmw5JoKNnRD5Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "kramed": "bin/kramed"
+      }
+    },
+    "node_modules/kramed-text-renderer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/kramed-text-renderer/-/kramed-text-renderer-0.2.1.tgz",
+      "integrity": "sha512-uYGzm0jhGROPHK0NAj8ukuIFBLvOvx/CtqyYtI7Sz3ZeNCWVOJkrun9AVuGbAMmBiImCuXxYG93lcBLHiQ9ASQ==",
+      "dev": true,
+      "license": "Apache v2"
+    },
+    "node_modules/lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/opal-npm-wrapper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/opal-npm-wrapper/-/opal-npm-wrapper-0.1.1.tgz",
+      "integrity": "sha512-XkDxVSPyQaqRUDGzLmlUc053UQMYYYCCrBtNPtRTZyjroyPQoUOpzUcaQmOgRHi3g4wbTG/+FKY2elKTP2fhtA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+      "integrity": "sha512-z6TbUngjp7wMWIKNeUTuA24oRTW+HGCN7LlBgUPfNzCv5J/JsLsuF/qBh6tCUS2+ALGQ/4U5W4L4yUk7qIFWrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xmlhttprequest": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.6.0.tgz",
+      "integrity": "sha512-Di/j1IntyXnpdHO61iC75URYQpF7QnuS0fLpuHTpNNhkA0291BZGMoHPJi6lIQ9Z7PjA28aqSLdG1m76P5hUPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
update the x402 demo link from "https://agents.injective.com/x402-v5" to "https://agents.injective.com/x402" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Getting started" guide to reference the current demo URL endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->