### PR TITLE
docs: chain release v1.20.1

### DIFF
--- a/.gitbook/docs.json
+++ b/.gitbook/docs.json
@@ -231,6 +231,7 @@
                       "infra/validator-mainnet/index",
                       "infra/validator-mainnet/peggo",
                       "infra/validator-mainnet/canonical-chain-upgrade",
+                      "infra/validator-mainnet/canonical-chain-upgrade-v1.20.1",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.20.0",
 		      "infra/validator-mainnet/canonical-chain-upgrade-v1.20.0-flag-changes",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.19.0",

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.1.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.1.mdx
@@ -1,12 +1,12 @@
 ---
-title: Upgrade to {/* $VERSION */}
-description: How to upgrade Injective Mainnet Validator node to {/* $VERSION */}
-updatedAt: "2025-12-03"
+title: Upgrade to v1.20.1
+description: How to upgrade Injective Mainnet Validator node to v1.20.1
+updatedAt: "2026-06-27"
 ---
 
-{/* $DATE (e.g. Tuesday, August 19th, 2025) */}
+Thursday, July 2nd, 2026
 
-Following [IIP {/* $PROPOSAL_NUM */}](https://injhub.com/proposal/{/* $PROPOSAL_NUM */}/) This indicates that the upgrade procedure should be performed on block number **{/* $BLOCK_NUM */}**
+Following [IIP-665](https://injhub.com/proposal/665/) This indicates that the upgrade procedure should be performed on block number **172502000**
 
 * [Summary](#summary)
 * [Recovery](#recovery)
@@ -15,13 +15,13 @@ Following [IIP {/* $PROPOSAL_NUM */}](https://injhub.com/proposal/{/* $PROPOSAL_
 
 ## Summary
 
-The Injective Chain will undergo a scheduled enhancement upgrade at approximately **{/* $DATE_TIME (e.g. Tuesday, August 19th, 2025, 14:00 UTC) */}**.
+The Injective Chain will undergo a scheduled enhancement upgrade at approximately **Thursday, July 2nd, 2026, 10:00 AM ET / 14:00 UTC**.
 
 The following is a short summary of the upgrade steps:
 
-1. Vote and wait till the node panics at block height **{/* $BLOCK_NUM */}**.
+1. Vote and wait till the node panics at block height **172502000**.
 2. Backing up configs, data, and keys used for running the Injective Chain.
-3. Install the [{/* $VERSION */}](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/{/* $VERSION */}-{/* $VERSION_ID */}) binaries.
+3. Install the [v1.20.1](https://github.com/InjectiveFoundation/injective-core/releases/tag/v1.20.1-1782532109) binaries.
 4. Start your node with the new injectived binary to fulfill the upgrade.
 
 Upgrade coordination and support for validators will be available on the `#validators` private channel of the [Injective Discord](https://discord.gg/injective).
@@ -42,7 +42,7 @@ Prior to exporting chain state, validators are encouraged to take a full data sn
 
 It is critically important to backup the `.injectived/data/priv_validator_state.json` file after stopping your injectived process. This file is updated every block as your validator participates in a consensus rounds. It is a critical file needed to prevent double-signing, in case the upgrade fails and the previous chain needs to be restarted.
 
-In the event that the upgrade does not succeed, validators and operators must restore the snapshot and downgrade back to Injective Chain release [{/* $VERSION_PREV */}](https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/{/* $VERSION_PREV */}-{/* $VERSION_ID_PREV */}) and continue this earlier chain until next upgrade announcement.
+In the event that the upgrade does not succeed, validators and operators must restore the snapshot and downgrade back to Injective Chain release [v1.20.0](https://github.com/InjectiveFoundation/injective-core/releases/tag/v1.20.0) and continue this earlier chain until next upgrade announcement.
 
 ## Upgrade Procedure
 
@@ -56,16 +56,13 @@ rm -rf .injectived/wasm/wasm/cache/
 
 ### Steps
 
-1.  Verify you are currently running the correct version (`{/* $VERSION_PREV */}`) of `injectived`:
+1.  Verify you are currently running the correct version (`v1.20.0`) of `injectived`:
 
-    {/* $INJECTIVED_PREV_OUTPUT */}
-    {/*  e.g.
     ```bash
     $ injectived version
-    Version v1.16.1 (8be67e82d)
-    Compiled at 20250802-1913 using Go go1.23.9
+    Version v1.20.0 (3ade14d)
+    Compiled at 20260530-0816 using Go go1.26.2 (amd64)
     ```
-    */}
 
 2.  Make a backup of your `.injectived` directory:
 
@@ -73,26 +70,22 @@ rm -rf .injectived/wasm/wasm/cache/
     cp -r ~/.injectived ./injectived-backup
     ```
 
-3. Download and install the `injective-chain` release for `{/* $VERSION */}`:
+3. Download and install the `injective-chain` release for v1.20.1:
 
     ```bash
-    wget https://github.com/InjectiveLabs/injective-chain-releases/releases/download/{/* $VERSION */}-{/* $VERSION_ID */}/linux-amd64.zip
+    wget https://github.com/InjectiveFoundation/injective-core/releases/download/v1.20.1-1782532109/linux-amd64.zip
     unzip linux-amd64.zip
     sudo mv injectived peggo /usr/bin
     sudo mv libwasmvm.x86_64.so /usr/lib
     ```
 
-4.  Verify you are currently running the correct version (`{/* $VERSION */}`) of `injectived` after downloading the `{/* $VERSION */}` release:
+4.  Verify you are currently running the correct version (v1.20.1) of `injectived` after downloading the v1.20.1 release:
 
-    {/* $INJECTIVED_OUTPUT - obtain using the following command
-        docker run -it --rm -v $HOME/.injectived:/root/.injectived injectivelabs/injective-core:$VERSION injectived --home /root/.injectived version */}
-    {/* e.g.
     ```bash
     $ injectived version
-    Version v1.16.2 (437674d)
-    Compiled at 20250814-2305 using Go go1.23.9
+    Version v1.20.1 (eef179e)
+    Compiled at 20260627-0349 using Go go1.26.4 (amd64)
     ```
-    */}
 
 5.  Start `injectived`:
 
@@ -100,17 +93,13 @@ rm -rf .injectived/wasm/wasm/cache/
     injectived start
     ```
 
-6.  Verify you are currently running the correct version (`{/* $VERSION */}`) of `peggo` after downloading the `{/* $VERSION */}` release:
+6.  Verify you are currently running the correct version (v1.20.1) of `peggo` after downloading the v1.20.1 release:
 
-    {/* $PEGGO_OUTPUT - obtain using the following command
-        docker run -it --rm -v $HOME/.injectived:/root/.injectived injectivelabs/injective-core:$VERSION peggo version */}
-    {/* e.g.
     ```bash
     $ peggo version
-    Version v1.16.2 (437674d)
-    Compiled at 20250814-2307 using Go go1.23.9
+    Version v1.20.1 (eef179e)
+    Compiled at 20260627-0356 using Go go1.26.4 (amd64)
     ```
-    */}
 
 7.  Start peggo:
 

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.1.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.1.mdx
@@ -54,6 +54,16 @@ You must remove the wasm cache before upgrading to the new version:
 rm -rf .injectived/wasm/wasm/cache/
 ```
 
+### Breaking changes
+
+<Warning>
+    Verify that you make the following changes as part of the upgrade process.
+</Warning>
+
+The Go build environment has changed.
+In the previous release, the Go version was 1.26.2 (`go1.26.2`).
+Update your Go version to 1.26.4 (`go1.26.4`).
+
 ### Steps
 
 1.  Verify you are currently running the correct version (`v1.20.0`) of `injectived`:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Mainnet Validator upgrade guide for v1.20.1.
  * Expanded upgrade steps with version checks, backup guidance, installation instructions, and service restart details.
  * Included recovery, rollback, and expected-outcome notes for different upgrade scenarios.
  * Updated the docs navigation and clarified upgrade timing wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->