### PR TITLE
docs: new tutorial for AI SDK

### DIFF
--- a/.gitbook/developers-ai/ai-sdk.mdx
+++ b/.gitbook/developers-ai/ai-sdk.mdx
@@ -1,0 +1,180 @@
+---
+title: AI SDK
+description: >-
+    Install the Injective AI SDK to get the Injective CLI, MCP servers, and agent skills in one package.
+updatedAt: "2026-07-01"
+---
+
+Building with AI on Injective usually means stitching together several moving parts:
+a command-line interface (CLI),
+one or more Model Context Protocol (MCP) servers, and
+harness-friendly agent skills for tools such as Codex or Claude Code.
+`@bguiz/ainj` packages those pieces into a single install,
+so you can set them up once and start building faster.
+
+In this tutorial you will:
+
+- Install AInj
+  - Install globally via `npm`
+  - Configure AInj and your preferred harness with `ainj install`
+  - Verify your setup with `ainj status` and `ainj skills`
+- Run an Injective CLI command
+- Invoke an Injective agent skill
+- Run both Injective MCP servers
+
+## Prerequisites
+
+| Tool | Minimum version | How to check | Install link |
+| --- | --- | --- | --- |
+| Node.js | `24.0.0` | `node --version` | [Node.js](https://nodejs.org/en/download) |
+| npm | `11.0.0` | `npm --version` | [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) |
+| Git | `2.53.0` | `git --version` | [Git](https://git-scm.com/downloads) |
+| Codex | `0.139.0` | `codex --version` | [Codex](https://platform.openai.com/docs/codex) |
+| Claude Code | `2.1.81` | `claude --version` | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) |
+
+Note that you only need one harness (Codex or Claude Code).
+
+You also need:
+
+- A terminal session with permission to install a global `npm` package
+- A local project or working directory where your harness can read configuration files
+
+## Get started
+
+The Injective AI SDK is open source at [bguiz/ainj](https://github.com/bguiz/ainj).
+This contains the source code for the package you are about to install.
+
+```shell
+npm install -g @bguiz/ainj
+```
+
+<Info>
+If you would like to develop/ contribute to AInj:
+
+```shell
+git clone https://github.com/bguiz/ainj.git
+cd ainj
+```
+
+However, note that this tutorial will focus on using AInj, rather than on contributing to it.
+</Info>
+
+## What does `ainj install` configure?
+
+`ainj install` writes AInj state, configures MCP entries for supported harnesses,
+and installs bundled skills so your AI tooling can use Injective-aware prompts and transports without manual wiring.
+
+In practice, the setup flow does three useful jobs:
+
+1. It saves AInj state, including scope, ports, and default harness.
+2. It adds MCP entries for both stdio and HTTP transports to your harness configurations.
+3. It installs the agent skills so a harness can invoke them.
+
+<Info>
+You must run `ainj install` once.
+It includes interactive prompts, which are used to configure the installation.
+</Info>
+
+## Installing and configuring AInj
+
+1. Run `ainj install` in your terminal.
+2. Select the options from the installation wizard
+    - Choose `global` (recommended).
+      - Unless you want the configuration to apply only within the current directory.
+    - Keep the default ports `3001` and `3002` for the MCP servers (or choose others).
+    - Select the harnesses you want AInj to configure, such as `Codex` or `Claude Code`.
+    - Select which agent skills you wish to install.
+
+When the command finishes, you should see `AInj configured` in the terminal.
+
+## Checking your AInj setup
+
+1. Run `ainj status`
+2. Inspect the installed version, configured scope, selected ports, default harness, and agent skills.
+3. Confirm that all of these values match your expectations
+    - If any of them are incorrect, simply re-run `ainj install`.
+
+<Info>
+Note that `ainj status` only shows the number of available agent skills.
+To see the full list of available skills, run `ainj skills`.
+</Info>
+
+## Running Injective CLI commands
+
+1. Run `ainj cli version` to confirm that AInj can resolve the bundled `injectived` binary.
+2. Run `ainj cli --help` if you want to inspect the CLI surface before moving on to chain-specific commands.
+
+You should see version output for the bundled Injective CLI,
+which confirms the binary is installed and callable through AInj.
+
+<Info>
+Note that `ainj injectived` is an alias for `ainj cli`.
+</Info>
+
+## Running an Injective agent skill from your harness
+
+1. Start your preferred harness (e.g. Codex or Claude Code).
+2. Enter a prompt that references a previously installed agent skill
+    - For example, if you want to build a smart contract or dApp on Injective:
+    - In Codex, use `$injective-evm-developer (... your smart contract/ dApp idea)`
+    - In Claude Code, use `/injective-evm-developer (... your smart contract/ dApp idea)`
+3. Thereafter the agent skill will be loaded into the context window,
+   and you can interact with it.
+
+<Info>
+Note that your harness should provide tab-to-auto-complete your skills names,
+e.g. when you type `$inj` (Codex) or `/inj` (Claude Code) there should be several injective-related
+agent skills listed for you to choose from.
+
+If you do this, and skills with matching names do not appear,
+you likely have not installed them yet.
+Re-run `ainj install` to trigger a reinstallation of the agent-skills.
+</Info>
+
+## Starting the documentation MCP server
+
+1. Run `ainj mcp docs http` in a dedicated terminal window.
+    - Keep this terminal open while the server is running.
+2. Connect an MCP client to `http://localhost:3002/mcp`.
+    - Change the port number if you have configured a non-default value.
+3. Issue some MCP tool calls.
+
+<Info>
+Alternatively, if you do not already have an MCP client,
+you can point an inspector at the same URL to inspect the available tools, and manually issue tool calls.
+
+See the ["Inspecting MCP servers"](https://github.com/bguiz/ainj#inspecting-mcp-servers) section in the README.
+</Info>
+
+The Injective docs MCP server should stay running, and your MCP client should be able to connect to it.
+
+## Starting the main Injective MCP server
+
+1. Run `ainj mcp main http`.
+    - Open another terminal window so you can keep the docs server running (if you want both MCP servers at the same time).
+    - Keep this terminal open while the server is running.
+2. Connect an MCP client to `http://localhost:3001/mcp`
+    - Change the port number if you have configured a non-default value.
+3. Issue some MCP tool calls
+
+## Next steps
+
+You now have AInj installed, configured, and running across workflows spanning CLI, agent skills, and MCP servers.
+
+Here is what you learnt:
+
+- how to install AInj as a single entry point for Injective AI development
+- how to configure harness integrations and MCP ports with `ainj install`
+- how to verify the setup with `ainj status` and `ainj skills`
+- how to use the CLI, agent skills, and both MCP servers
+
+From here, continue with the rest of the AI developer docs:
+
+- [AI developers overview](/developers-ai/)
+- [Injective main MCP server](/developers-ai/mcp)
+- [Injective documentation MCP server](/developers-ai/documentation-mcp)
+- [Injective CLI agent skill](/developers-ai/injective-cli-skill)
+- [Injective EVM Developer agent skill](/developers-ai/injective-evm-developer-skill)
+- [Injective MCP Servers agent skill](/developers-ai/injective-mcp-servers-skill)
+- [Injective Trading agent skills](/developers-ai/injective-trading-skills)
+- [Injective x402](/developers-ai/x402)

--- a/.gitbook/developers-ai/ai-sdk.mdx
+++ b/.gitbook/developers-ai/ai-sdk.mdx
@@ -49,7 +49,7 @@ npm install -g @bguiz/ainj
 ```
 
 <Info>
-If you would like to develop/ contribute to AInj:
+If you would like to develop or contribute to AInj:
 
 ```shell
 git clone https://github.com/bguiz/ainj.git
@@ -122,13 +122,13 @@ Note that `ainj injectived` is an alias for `ainj cli`.
    and you can interact with it.
 
 <Info>
-Note that your harness should provide tab-to-auto-complete your skills names,
+Note that your harness should provide tab completion for skill names,
 e.g. when you type `$inj` (Codex) or `/inj` (Claude Code) there should be several injective-related
 agent skills listed for you to choose from.
 
 If you do this, and skills with matching names do not appear,
 you likely have not installed them yet.
-Re-run `ainj install` to trigger a reinstallation of the agent-skills.
+Re-run `ainj install` to trigger a reinstallation of the agent skills.
 </Info>
 
 ## Starting the documentation MCP server

--- a/.gitbook/developers-ai/ai-sdk.mdx
+++ b/.gitbook/developers-ai/ai-sdk.mdx
@@ -9,7 +9,7 @@ Building with AI on Injective usually means stitching together several moving pa
 a command-line interface (CLI),
 one or more Model Context Protocol (MCP) servers, and
 harness-friendly agent skills for tools such as Codex or Claude Code.
-`@bguiz/ainj` packages those pieces into a single install,
+`@injectivelabs/ainj` packages those pieces into a single install,
 so you can set them up once and start building faster.
 
 In this tutorial you will:
@@ -41,23 +41,11 @@ You also need:
 
 ## Get started
 
-The Injective AI SDK is open source at [bguiz/ainj](https://github.com/bguiz/ainj).
-This contains the source code for the package you are about to install.
+Install the Injective AI SDK globally with `npm`:
 
 ```shell
-npm install -g @bguiz/ainj
+npm install -g @injectivelabs/ainj
 ```
-
-<Info>
-If you would like to develop or contribute to AInj:
-
-```shell
-git clone https://github.com/bguiz/ainj.git
-cd ainj
-```
-
-However, note that this tutorial will focus on using AInj, rather than on contributing to it.
-</Info>
 
 ## What does `ainj install` configure?
 
@@ -142,8 +130,6 @@ Re-run `ainj install` to trigger a reinstallation of the agent skills.
 <Info>
 Alternatively, if you do not already have an MCP client,
 you can point an inspector at the same URL to inspect the available tools, and manually issue tool calls.
-
-See the ["Inspecting MCP servers"](https://github.com/bguiz/ainj#inspecting-mcp-servers) section in the README.
 </Info>
 
 The Injective docs MCP server should stay running, and your MCP client should be able to connect to it.

--- a/.gitbook/developers-ai/index.mdx
+++ b/.gitbook/developers-ai/index.mdx
@@ -36,12 +36,12 @@ You can use all of them when building on Injective.
     These can be anything from functions, to scripts, to command-line interfaces (CLIs) that are packaged up in a manner
     that make them understood or callable by LLMs.
     For example, if you want the LLM to access real-time information,
-    i.e. information that was no available to it when the LLM was trained,
+    i.e. information that was not available to it when the LLM was trained,
     you would need to give it access to call tools for web searches or other data APIs.
     Note that even when these are not adapted for use by LLMs,
-    agent skills may be use to provide thin wrappers around them.
+    agent skills may be used to provide thin wrappers around them.
 - **MCP** -
-    Model-Context-Protocol (MCP) is a protocol designed for discovery and calling of tools by LLMs.
+    Model Context Protocol (MCP) is a protocol designed for discovery and calling of tools by LLMs.
     They are designed to standardize the way for different LLMs and LLM providers to invoke tools.
     Previously each LLM or LLM provider had competing standards/ protocols for doing so.
 - **Agent Skills** -
@@ -52,7 +52,7 @@ You can use all of them when building on Injective.
     They can be recursive, for example a skill can reference other skills.
     These are sometimes also referred to as "workflows", "subagents", and "agents".
     In this context, workflows are usually a set of skills with a defined order;
-    and agents/ subagents are are sets of workflows and skills with no specified order,
+    and agents/ subagents are sets of workflows and skills with no specified order,
     where the LLM is given agency over which ones to use and in what order.
     Note that the term "agents" is overused, with multiple definitions,
     so the above definition is specific to this context.
@@ -64,7 +64,7 @@ You can use all of them when building on Injective.
 - **AI Engineering Harnesses** -
     These are command line interfaces (CLIs) or terminal user interfaces (TUIs) that are designed around
     invoking LLMs for coding tasks.
-    The operate directly on the file system, and often come with baked-in optimizations and utilities for engineering tasks.
+    They operate directly on the file system, and often come with baked-in optimizations and utilities for engineering tasks.
     These tend to be more powerful than working with AI engineering IDEs,
     as they work best when skills, workflows, and agents are used.
     Popular ones include: Claude Code (Anthropic), Codex (OpenAI), and OpenCode (unaffiliated).
@@ -86,7 +86,7 @@ In fact, that is the point of this **AI Developers** section!
 
 Injective makes it easy for you to develop using AI.
 Use the [Injective AI SDK](/developers-ai/ai-sdk/)
-which provides you agent skills, CLI, MCP servers - all in a single install.
+which provides you with agent skills, CLI, and MCP servers - all in a single install.
 
 ## Agent skills
 

--- a/.gitbook/developers-ai/index.mdx
+++ b/.gitbook/developers-ai/index.mdx
@@ -3,7 +3,7 @@ title: AI developers
 description: >-
     How to build AI-powered applications and agents on Injective,
     including generative AI tools, MCP servers, and agent skills.
-updatedAt: "2026-03-10"
+updatedAt: "2026-07-01"
 ---
 
 ## Why build using generative AI tools on Injective?
@@ -14,12 +14,16 @@ You will find skills, agents, workflows, and MCP servers here that will help you
 
 ## What types of generative AI tools are available?
 
+LLMs, LLM providers, MCP servers, agent skills, CLIs/SDKs/functions/scripts,
+AI engineering IDEs/Harnesses/Orchestrators are various types of generative AI tools.
+You can use all of them when building on Injective.
+
 - **LLMs** -
     Large language models (LLMs) are the base-layer technology powering almost all generative AI software engineering.
     Almost all AI development tools are wrappers around LLMs.
     Popular ones include Claude Opus (Anthropic), Gemini (Google), and Kimi (Moonshot AI).
 - **LLM Providers** -
-    Low- and mid-tier LLMs are possible to run on retail/ consumer hardware.
+    Low-tier and mid-tier LLMs are possible to run on retail/ consumer hardware.
     However the top-tier LLMs need to be accessed remotely.
     You have 3 main options:
     - **Local providers** -
@@ -28,39 +32,43 @@ You will find skills, agents, workflows, and MCP servers here that will help you
       For example, accessing Claude Opus via an Anthropic subscription.
     - **Remote providers from model aggregators** -
       For example, accessing Claude Opus, Gemini, or Kimi via an OpenRouter subscription.
-- **Tools** -
+- **CLIs, SDKs, functions, and scripts** -
     These can be anything from functions, to scripts, to command-line interfaces (CLIs) that are packaged up in a manner
     that make them understood or callable by LLMs.
     For example, if you want the LLM to access real-time information,
     i.e. information that was no available to it when the LLM was trained,
     you would need to give it access to call tools for web searches or other data APIs.
+    Note that even when these are not adapted for use by LLMs,
+    agent skills may be use to provide thin wrappers around them.
 - **MCP** -
     Model-Context-Protocol (MCP) is a protocol designed for discovery and calling of tools by LLMs.
     They are designed to standardize the way for different LLMs and LLM providers to invoke tools.
     Previously each LLM or LLM provider had competing standards/ protocols for doing so.
-- **Skills** -
-    These are markdown files that optionally reference supporting resources, tools, MCP servers and others.
-    They are designed specifically to work with AI engineering harnesses (but can be used in other contexts).
+- **Agent Skills** -
+    These are markdown files that primarily include a detailed repeatable prompt.
+    They optionally reference supporting resources, tools, MCP servers and others.
+    They are designed specifically to work with AI engineering harnesses,
+    but can be used in other contexts too.
     They can be recursive, for example a skill can reference other skills.
     These are sometimes also referred to as "workflows", "subagents", and "agents".
     In this context, workflows are usually a set of skills with a defined order;
     and agents/ subagents are are sets of workflows and skills with no specified order,
     where the LLM is given agency over which ones to use and in what order.
     Note that the term "agents" is overused, with multiple definitions,
-    so the above is specific to this context.
-- **AI engineering IDEs** -
+    so the above definition is specific to this context.
+- **AI Engineering IDEs** -
     These are either dedicated IDEs or plugins within IDEs that allow you to prompt LLMs,
     including execution of tool calls or MCPs,
     and use their output to work on the code base that is open within the IDE.
     Popular ones include: Roo, Cline, and Cursor.
-- **AI engineering Harnesses** -
+- **AI Engineering Harnesses** -
     These are command line interfaces (CLIs) or terminal user interfaces (TUIs) that are designed around
     invoking LLMs for coding tasks.
     The operate directly on the file system, and often come with baked-in optimizations and utilities for engineering tasks.
     These tend to be more powerful than working with AI engineering IDEs,
     as they work best when skills, workflows, and agents are used.
     Popular ones include: Claude Code (Anthropic), Codex (OpenAI), and OpenCode (unaffiliated).
-- **AI engineering Orchestrators** -
+- **AI Engineering Orchestrators** -
     These are tools that act as wrappers around harnesses.
     Their main intent is to enable long-running loops or parallelization of harness invocation,
     such that it becomes possible have LLMs working autonomously on longer and more complex tasks
@@ -73,6 +81,12 @@ LLMs, LLM Providers, Tools, MCP, Skills, Workflows, Agents, AI engineering IDEs,
 AI engineering Harnesses, AI engineering Orchestrators.
 In short, all of them!
 In fact, that is the point of this **AI Developers** section!
+
+## AI SDK
+
+Injective makes it easy for you to develop using AI.
+Use the [Injective AI SDK](/developers-ai/ai-sdk/)
+which provides you agent skills, CLI, MCP servers - all in a single install.
 
 ## Agent skills
 

--- a/.gitbook/docs.json
+++ b/.gitbook/docs.json
@@ -194,6 +194,7 @@
                 "expanded": false,
                 "pages": [
                   "developers-ai/index",
+                  "developers-ai/ai-sdk",
                   "developers-ai/injective-cli-skill",
                   "developers-ai/injective-evm-developer-skill",
                   "developers-ai/injective-mcp-servers-skill",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **AI SDK** guide explaining how to install and configure the Injective AI SDK, including how to verify setup (status/skills), run the CLI, and launch MCP servers (docs + main) with example endpoints and client connection guidance.
  * Updated the **AI Developers** overview with revised wording and an expanded/restructured list of generative AI tool categories (including Agent Skills, MCP, and orchestrators).
  * Updated developer docs navigation to include the new **AI SDK** page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->