### PR TITLE
Add Envio to Data Indexing & Querying

### DIFF
--- a/.gitbook/developers-evm/infrastructure-and-tooling.mdx
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.mdx
@@ -30,6 +30,9 @@ Envio is a high-performance indexing framework that turns smart contract events 
 <li>
 <a href="https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=injective&utm_medium=partner-docs">Indexing via RPC quick start</a>
 </li>
+<li>
+<a href="https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=injective&utm_medium=partner-docs">Benchmarks</a>
+</li>
 </ul>
 </td>
 </tr>

--- a/.gitbook/developers-evm/infrastructure-and-tooling.mdx
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.mdx
@@ -30,9 +30,6 @@ Envio is the data layer for blockchain apps. It gives Injective developers the f
 <li>
 <a href="https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=injective&utm_medium=partner-docs">Indexing via RPC quick start</a>
 </li>
-<li>
-<a href="https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=injective&utm_medium=partner-docs">Benchmarks</a>
-</li>
 </ul>
 </td>
 </tr>

--- a/.gitbook/developers-evm/infrastructure-and-tooling.mdx
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.mdx
@@ -18,6 +18,22 @@ BlockScoutInjective is supported by a rich ecosystem of industry-leading infrast
 </thead>
 <tbody>
 <tr>
+<td><a href="https://envio.dev/?utm_source=injective&utm_medium=partner-docs">Envio</a></td>
+<td>
+<p>
+Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index Injective inEVM by pointing an indexer at your own RPC as the data source.
+</p>
+<ul>
+<li>
+<a href="https://docs.envio.dev/docs/HyperIndex/overview?utm_source=injective&utm_medium=partner-docs">HyperIndex overview</a>
+</li>
+<li>
+<a href="https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=injective&utm_medium=partner-docs">Indexing via RPC quick start</a>
+</li>
+</ul>
+</td>
+</tr>
+<tr>
 <td><a href="https://thegraph.com/networks/injective/?subnetwork=injective-testnet">The Graph</a></td>
 <td>
 <p>

--- a/.gitbook/developers-evm/infrastructure-and-tooling.mdx
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.mdx
@@ -21,7 +21,7 @@ BlockScoutInjective is supported by a rich ecosystem of industry-leading infrast
 <td><a href="https://envio.dev/?utm_source=injective&utm_medium=partner-docs">Envio</a></td>
 <td>
 <p>
-Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index Injective inEVM by pointing an indexer at your own RPC as the data source.
+Envio is the data layer for blockchain apps. It gives Injective developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index Injective inEVM by pointing an indexer at your own RPC as the data source.
 </p>
 <ul>
 <li>

--- a/.gitbook/developers-evm/infrastructure-and-tooling.mdx
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.mdx
@@ -30,6 +30,9 @@ Envio is the data layer for blockchain apps. It gives Injective developers the f
 <li>
 <a href="https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=injective&utm_medium=partner-docs">Supported networks</a>
 </li>
+<li>
+<a href="https://envio.dev/chains/injective?utm_source=injective&utm_medium=partner-docs">Index Injective with Envio</a>
+</li>
 </ul>
 </td>
 </tr>

--- a/.gitbook/developers-evm/infrastructure-and-tooling.mdx
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.mdx
@@ -21,7 +21,7 @@ BlockScoutInjective is supported by a rich ecosystem of industry-leading infrast
 <td><a href="https://envio.dev/?utm_source=injective&utm_medium=partner-docs">Envio</a></td>
 <td>
 <p>
-Envio is the data layer for blockchain apps. It gives Injective developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Injective EVM is natively supported by Envio's HyperSync, so HyperIndex can index it out of the box.
+Envio is the data layer for blockchain apps. It gives Injective developers a flexible way to access real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Injective EVM is natively supported by Envio's HyperSync, so HyperIndex can index it out of the box.
 </p>
 <ul>
 <li>

--- a/.gitbook/developers-evm/infrastructure-and-tooling.mdx
+++ b/.gitbook/developers-evm/infrastructure-and-tooling.mdx
@@ -21,14 +21,14 @@ BlockScoutInjective is supported by a rich ecosystem of industry-leading infrast
 <td><a href="https://envio.dev/?utm_source=injective&utm_medium=partner-docs">Envio</a></td>
 <td>
 <p>
-Envio is the data layer for blockchain apps. It gives Injective developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index Injective inEVM by pointing an indexer at your own RPC as the data source.
+Envio is the data layer for blockchain apps. It gives Injective developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Injective EVM is natively supported by Envio's HyperSync, so HyperIndex can index it out of the box.
 </p>
 <ul>
 <li>
 <a href="https://docs.envio.dev/docs/HyperIndex/overview?utm_source=injective&utm_medium=partner-docs">HyperIndex overview</a>
 </li>
 <li>
-<a href="https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=injective&utm_medium=partner-docs">Indexing via RPC quick start</a>
+<a href="https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=injective&utm_medium=partner-docs">Supported networks</a>
 </li>
 </ul>
 </td>


### PR DESCRIPTION
This PR adds Envio to the Data Indexing & Querying section.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Injective EVM is natively supported by Envio's HyperSync, so HyperIndex can index it out of the box. The entry follows the existing table format used in the section and links to the HyperIndex overview, the supported networks page and the Injective chain page.

Links:
- Website: https://envio.dev
- Docs: https://docs.envio.dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Envio” entry to the **Data Indexing & Querying** resources table.
  * Included an Envio link along with related HyperIndex resource links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
