### PR TITLE
docs: hide add wallet interactive page

### DIFF
--- a/.gitbook/docs.json
+++ b/.gitbook/docs.json
@@ -43,7 +43,6 @@
             "group": "INJECTIVE",
             "pages": [
               "index",
-              "add-network-to-wallet",
               {
                 "group": "DeFi",
                 "icon": "coins",


### PR DESCRIPTION
avoid parsing error with Mintlify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the “Add Network to Wallet” page from the English documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->