### PR TITLE
docs: link OpenChainBench public Injective RPC latency benchmark

### DIFF
--- a/.gitbook/infra/public-endpoints.mdx
+++ b/.gitbook/infra/public-endpoints.mdx
@@ -54,3 +54,9 @@ For more EVM network details including Chain ID, contracts, and additional provi
 | Explorer         | https://testnet.explorer.injective.network/                           |
 | Faucet           | https://testnet.faucet.injective.network/                             |
 | Status           | https://uptime.com/statuspage/testnet.status.injective.network                            |
+
+## Public latency benchmarks
+
+For integrators comparing public Injective RPC providers, [OpenChainBench](https://openchainbench.com/benchmarks/injective-rpc) publishes a continuous latency benchmark of the Tendermint `status` method across the Injective Foundation endpoint and community providers (PublicNode, Polkachu, LavenderFive). Probes run every 60s from Paris, Virginia, and Singapore.
+
+Source and methodology: [github.com/ChainBench/openchainbench](https://github.com/ChainBench/openchainbench).

--- a/.gitbook/infra/public-endpoints.mdx
+++ b/.gitbook/infra/public-endpoints.mdx
@@ -57,6 +57,6 @@ For more EVM network details including Chain ID, contracts, and additional provi
 
 ## Public latency benchmarks
 
-For integrators comparing public Injective RPC providers, [OpenChainBench](https://openchainbench.com/benchmarks/injective-rpc) publishes a continuous latency benchmark of the Tendermint `status` method across the Injective Foundation endpoint and community providers (PublicNode, Polkachu, LavenderFive). Probes run every 60s from Paris, Virginia, and Singapore.
+For integrators comparing public Injective RPC providers, [OpenChainBench](https://openchainbench.com/benchmarks/injective-rpc) publishes a continuous latency benchmark of the Tendermint `status` method across the Injective Foundation endpoint and community providers (PublicNode, Polkachu, LavenderFive). Probes run every 60s from Amsterdam, Virginia, and Singapore.
 
 Source and methodology: [github.com/ChainBench/openchainbench](https://github.com/ChainBench/openchainbench).


### PR DESCRIPTION
## Summary

Adds a short section to `Public Endpoints` linking to [OpenChainBench](https://openchainbench.com/benchmarks/injective-rpc), a public, open-source latency benchmark for Injective's Tendermint RPC providers. It probes the Injective Foundation endpoint and community providers (PublicNode, Polkachu, LavenderFive) every 60s from three regions (Paris, Virginia, Singapore) using the `status` method.

Intended as a neutral cross-check for integrators picking between the free public RPC options already listed on this page.

Source and methodology are open: https://github.com/ChainBench/openchainbench

Precedent for this kind of addition:
- osmosis-labs/docs#349
- jup-ag/docs#939

## Change

- 4 lines added to `.gitbook/infra/public-endpoints.mdx` under a new `## Public latency benchmarks` heading.
- No endpoint changes, no removals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Public latency benchmarks” section describing continuous Tendermint `status` latency measurements.
  * Included benchmark frequency, probe locations, participating providers, and links to the source and methodology repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->