### PR TITLE
docs: chain release v1.20.3

### DIFF
--- a/.gitbook/docs.json
+++ b/.gitbook/docs.json
@@ -233,6 +233,7 @@
                       "infra/validator-mainnet/index",
                       "infra/validator-mainnet/peggo",
                       "infra/validator-mainnet/canonical-chain-upgrade",
+                      "infra/validator-mainnet/canonical-chain-upgrade-v1.20.3",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.20.1",
                       "infra/validator-mainnet/canonical-chain-upgrade-v1.20.0",
 		      "infra/validator-mainnet/canonical-chain-upgrade-v1.20.0-flag-changes",

--- a/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.3.mdx
+++ b/.gitbook/infra/validator-mainnet/canonical-chain-upgrade-v1.20.3.mdx
@@ -1,0 +1,108 @@
+---
+title: Upgrade to v1.20.3
+description: How to upgrade Injective Mainnet Validator node to v1.20.3
+updatedAt: "2026-07-25"
+---
+
+Wednesday, July 29th, 2026
+
+Following [IIP-677](https://injhub.com/proposal/677/), the upgrade procedure should be performed at block height **176273000**.
+
+* [Summary](#summary)
+* [Recovery](#recovery)
+* [Upgrade Procedure](#upgrade-procedure)
+* [Notes for Validators](#notes-for-validators)
+
+## Summary
+
+The Injective Chain will undergo a scheduled enhancement upgrade at approximately **Wednesday, July 29th, 2026, 10:00 AM ET / 14:00 UTC**.
+
+The following is a short summary of the upgrade steps:
+
+1. Vote and wait till the node panics at block height **176273000**.
+2. Backing up configs, data, and keys used for running the Injective Chain.
+3. Install the [v1.20.3](https://github.com/InjectiveFoundation/injective-core/releases/tag/v1.20.3-1784976496) binaries.
+4. Start your node with the new injectived binary to fulfill the upgrade.
+
+Upgrade coordination and support for validators will be available on the `#validators` private channel of the [Injective Discord](https://discord.gg/injective).
+
+The network upgrade can take the following potential pathways:
+
+1. **Happy path**:\
+   Validators successfully upgrade the chain without purging the blockchain history, and all validators are up within 5-10 minutes of the upgrade.
+2. **Not-so-happy path**:\
+   Validators have trouble upgrading to the latest Canonical chain.
+3. **Abort path**:\
+   In the rare event that the team becomes aware of unnoticed critical issues, the Injective team will attempt to patch all the breaking states and provide another official binary within 36 hours.\
+   If the chain is not successfully resumed within 36 hours, the upgrade will be announced as aborted on the `#validators` channel in [Injective's Discord](https://discord.gg/injective), and validators will need to resume running the chain without any updates or changes.
+
+## Recovery
+
+Prior to exporting chain state, validators are encouraged to take a full data snapshot at the export height before proceeding. Snapshotting depends heavily on infrastructure, but generally this can be done by backing up the `.injectived` directory.
+
+It is critically important to backup the `.injectived/data/priv_validator_state.json` file after stopping your injectived process. This file is updated every block as your validator participates in consensus rounds. It is a critical file needed to prevent double-signing in case the upgrade fails and the previous chain needs to be restarted.
+
+In the event that the upgrade does not succeed, validators and operators must restore the snapshot and downgrade back to Injective Chain release [v1.20.1](https://github.com/InjectiveFoundation/injective-core/releases/tag/v1.20.1-1782532109) and continue this earlier chain until the next upgrade announcement.
+
+## Upgrade Procedure
+
+### Notes for Validators
+
+You must remove the wasm cache before upgrading to the new version:
+
+```shell
+rm -rf .injectived/wasm/wasm/cache/
+```
+
+### Steps
+
+1.  Verify you are currently running the correct version (`v1.20.1`) of `injectived`:
+
+    ```bash
+    $ injectived version
+    Version v1.20.1 (eef179e)
+    Compiled at 20260627-0349 using Go go1.26.4 (amd64)
+    ```
+
+2.  Make a backup of your `.injectived` directory:
+
+    ```bash
+    cp -r ~/.injectived ./injectived-backup
+    ```
+
+3. Download and install the `injective-chain` release for v1.20.3:
+
+    ```bash
+    wget https://github.com/InjectiveFoundation/injective-core/releases/download/v1.20.3-1784976496/linux-amd64.zip
+    unzip linux-amd64.zip
+    sudo mv injectived peggo /usr/bin
+    sudo mv libwasmvm.x86_64.so /usr/lib
+    ```
+
+4.  Verify you are currently running the correct version (v1.20.3) of `injectived` after downloading the v1.20.3 release:
+
+    ```bash
+    $ injectived version
+    Version v1.20.3 (5c3143e)
+    Compiled at 20260725-1049 using Go go1.26.4 (amd64)
+    ```
+
+5.  Start `injectived`:
+
+    ```bash
+    injectived start
+    ```
+
+6.  Verify you are currently running the correct version (v1.20.3) of `peggo` after downloading the v1.20.3 release:
+
+    ```bash
+    $ peggo version
+    Version v1.20.3 (5c3143e)
+    Compiled at 20260725-1056 using Go go1.26.4 (amd64)
+    ```
+
+7.  Start peggo:
+
+    ```bash
+    peggo orchestrator
+    ```


### PR DESCRIPTION
## Summary

- add the v1.20.3 Mainnet validator upgrade guide for IIP-677
- document the upgrade height and time, rollback procedure, release download, and binary version metadata
- add the new guide to the Mainnet Validator navigation

## Validation

- parsed `.gitbook/docs.json` as JSON
- parsed the new page with the repository's Markdown parser
- verified the release asset URL resolves successfully
- ran `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Mainnet Validator guide for upgrading to canonical chain version v1.20.3.
  * Included upgrade timing, target block height, installation steps, backup guidance, and recovery procedures.
  * Documented expected upgrade outcomes, including rollback instructions to v1.20.1.
* **Documentation**
  * Added the v1.20.3 upgrade guide to the Mainnet Validator documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->