### PR TITLE
docs: fix 104 dead documentation links across all language trees

### DIFF
--- a/.gitbook/cn/defi/tokens/inj-coin.mdx
+++ b/.gitbook/cn/defi/tokens/inj-coin.mdx
@@ -48,7 +48,7 @@ INJ 用于治理链的所有方面，包括：
 * Peggy 模块参数
 * Wasmx 模块参数
 * 软件升级
-* Cosmos-SDK 模块参数，包括 [auth](https://docs.cosmos.network/main/modules/auth#parameters)、[bank](https://docs.cosmos.network/main/modules/bank)、[crisis](https://docs.cosmos.network/main/modules/crisis)、[distribution](https://docs.cosmos.network/main/modules/distribution)、[gov](https://docs.cosmos.network/main/modules/gov)、[mint](https://docs.cosmos.network/main/modules/mint)、[slashing](https://docs.cosmos.network/main/modules/slashing) 和 [staking](https://docs.cosmos.network/main/modules/staking) 模块。
+* Cosmos-SDK 模块参数，包括 [auth](https://docs.cosmos.network/sdk/latest/modules/auth/auth#parameters)、[bank](https://docs.cosmos.network/sdk/latest/modules/bank/README)、[crisis](https://docs.cosmos.network/sdk/latest/modules/crisis/README)、[distribution](https://docs.cosmos.network/sdk/latest/modules/distribution/README)、[gov](https://docs.cosmos.network/sdk/latest/modules/gov/README)、[mint](https://docs.cosmos.network/sdk/latest/modules/mint/README)、[slashing](https://docs.cosmos.network/sdk/latest/modules/slashing/README) 和 [staking](https://docs.cosmos.network/sdk/latest/modules/staking/README) 模块。
 
 有关治理流程的完整详情，请参阅[这里](https://blog.injectiveprotocol.com/injective-governance-proposal-procedure)。
 

--- a/.gitbook/cn/defi/transaction-fees.mdx
+++ b/.gitbook/cn/defi/transaction-fees.mdx
@@ -8,7 +8,7 @@ updatedAt: "2026-02-03"
 <Callout icon="info" color="#07C1FF" iconType="regular">
 了解 Injective 上 `Gas` 和 `Fees` 之间的区别。
 
-前置阅读 → [Cosmos SDK Gas](https://docs.cosmos.network/main/build/modules/auth#gas--fees)
+前置阅读 → [Cosmos SDK Gas](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers)
 </Callout>
 
 Gas 代表在状态机上执行特定操作所需的计算工作量。
@@ -36,7 +36,7 @@ Gas 用于确保操作不需要过多的计算能力来完成，并阻止恶意�
 * `GasMeter`：跟踪导致状态转换的执行期间消耗的 gas。它在每次交易执行时重置。
 * `BlockGasMeter`：跟踪区块中消耗的 gas，并强制 gas 不超过预定义的限制。此限制在 Tendermint 共识参数中定义，可以通过治理参数更改提案进行更改。
 
-有关 Cosmos SDK 中 gas 的更多信息，请参阅[这里](https://docs.cosmos.network/main/learn/beginner/gas-fees)。
+有关 Cosmos SDK 中 gas 的更多信息，请参阅[这里](https://docs.cosmos.network/sdk/latest/learn/concepts/context-gas-events)。
 
 在 Cosmos 中，有些操作类型不是由交易触发的，但也可能导致状态转换。具体例子是 `BeginBlock` 和 `EndBlock` 操作以及 `AnteHandler` 检查，它们可能在运行交易的状态转换之前也会读取和写入存储。
 
@@ -46,4 +46,4 @@ Gas 用于确保操作不需要过多的计算能力来完成，并阻止恶意�
 
 #### `AnteHandler`
 
-Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/v0.45/modules/auth/03_antehandlers.html) 在交易执行之前执行基本检查。这些检查通常是签名验证、交易字段验证、交易费用等。
+Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers) 在交易执行之前执行基本检查。这些检查通常是签名验证、交易字段验证、交易费用等。

--- a/.gitbook/cn/defi/wallet/accounts.mdx
+++ b/.gitbook/cn/defi/wallet/accounts.mdx
@@ -10,7 +10,7 @@ updatedAt: "2026-02-03"
 
 前置阅读：
 
-* [Cosmos SDK 账户](https://docs.cosmos.network/main/basics/accounts)
+* [Cosmos SDK 账户](https://docs.cosmos.network/sdk/latest/learn/concepts/accounts)
 * [Ethereum 账户](https://ethereum.org/en/whitepaper/#ethereum-accounts)
 </Callout>
 

--- a/.gitbook/cn/developers-native/examples/authz.mdx
+++ b/.gitbook/cn/developers-native/examples/authz.mdx
@@ -30,7 +30,7 @@ updatedAt: "2026-02-13"
 "/injective.exchange.v1beta1.MsgWithdraw",
 ```
 
-根据 [cosmos sdk 文档](https://docs.cosmos.network/main/modules/authz)，"授权必须针对特定的 Msg 服务方法逐一授予"，因此以下代码片段必须针对您希望 `grantee` 代表 `granter` 拥有授权的每种消息类型重复执行。
+根据 [cosmos sdk 文档](https://docs.cosmos.network/sdk/latest/modules/authz/README)，"授权必须针对特定的 Msg 服务方法逐一授予"，因此以下代码片段必须针对您希望 `grantee` 代表 `granter` 拥有授权的每种消息类型重复执行。
 
 ```ts
 import { Network } from "@injectivelabs/networks";

--- a/.gitbook/cn/developers-native/transactions/web3-gateway.mdx
+++ b/.gitbook/cn/developers-native/transactions/web3-gateway.mdx
@@ -3,7 +3,7 @@ title: Web3 Gateway 交易
 updatedAt: "2026-02-13"
 ---
 
-_前置阅读 #1:_ [交易生命周期](https://docs.cosmos.network/main/basics/tx-lifecycle)
+_前置阅读 #1:_ [交易生命周期](https://docs.cosmos.network/sdk/latest/learn/concepts/lifecycle)
 
 _前置阅读 #2:_ Injective 上的交易
 

--- a/.gitbook/cn/developers-native/wallets/offchain-data.mdx
+++ b/.gitbook/cn/developers-native/wallets/offchain-data.mdx
@@ -3,7 +3,7 @@ title: 链下（任意）数据
 updatedAt: "2026-02-13"
 ---
 
-本页面将提供如何根据 Cosmos 的 [ADR-036](https://docs.cosmos.network/main/build/architecture/adr-036-arbitrary-signature) 规范签名和验证任意数据的示例。
+本页面将提供如何根据 Cosmos 的 [ADR-036](https://docs.cosmos.network/sdk/latest/reference/architecture/adr-036-arbitrary-signature) 规范签名和验证任意数据的示例。
 
 <Callout icon="info" color="#07C1FF" iconType="regular">
 你可以使用 `@injectivelabs/sdk-ts` 中的 `generateArbitrarySignDoc` 函数来生成 ADR-36 兼容的 `signDoc`。然后你可以在浏览器钱包或 CLI 环境中使用它进行签名/验证。请确保使用最新的包版本。

--- a/.gitbook/cn/infra/validator-mainnet/peggo.mdx
+++ b/.gitbook/cn/infra/validator-mainnet/peggo.mdx
@@ -186,7 +186,7 @@ Peggo 支持两种提供 Cosmos 签名密钥凭证的选项 - 使用 Cosmos keyr
 
 要使用默认的 injectived 密钥配置，你应该将 keyring 路径设置为你的 injectived 节点的主目录，例如 `~/.injectived`。
 
-你也可以在[这里](https://docs.cosmos.network/v0.46/run-node/keyring.html)阅读更多关于 Cosmos Keyring 设置的信息。
+你也可以在[这里](https://docs.cosmos.network/sdk/latest/node/keyring)阅读更多关于 Cosmos Keyring 设置的信息。
 
 #### **选项 2. Cosmos 私钥（不安全）**
 
@@ -282,7 +282,7 @@ journalctl -f -u peggo
 这是一个高级 DevOps 主题，请咨询你的系统管理员。
 </Callout>
 
-在[这里](https://docs.cosmos.network/v0.46/run-node/keyring.html)了解更多关于 Cosmos Keyring 设置的信息。一旦你启动了节点，默认的 keyring 将以加密形式将验证者操作员密钥存储在磁盘上。通常 keyring 位于节点的主目录中，即 `~/.injectived/keyring-file`。
+在[这里](https://docs.cosmos.network/sdk/latest/node/keyring)了解更多关于 Cosmos Keyring 设置的信息。一旦你启动了节点，默认的 keyring 将以加密形式将验证者操作员密钥存储在磁盘上。通常 keyring 位于节点的主目录中，即 `~/.injectived/keyring-file`。
 
 Injective 质押文档的某些部分将指导你使用此密钥进行治理目的，即提交交易和设置以太坊桥接。为了保护密钥免受未授权访问，即使 keyring 密码通过配置泄露，你也可以设置操作系统权限，仅允许 `injectived` / `peggo` 进程访问磁盘。
 

--- a/.gitbook/cn/infra/validator-testnet/peggo.mdx
+++ b/.gitbook/cn/infra/validator-testnet/peggo.mdx
@@ -29,7 +29,7 @@ Peggo 还需要访问你的验证者的 Cosmos 和以太坊凭证来为相应的
 
 如果你想重用那里的密钥，Keyring 路径必须指向你的 injectived 节点的主目录。
 
-在[这里](https://docs.cosmos.network/v0.46/run-node/keyring.html)了解更多关于 Keyring 设置的信息。
+在[这里](https://docs.cosmos.network/sdk/latest/node/keyring)了解更多关于 Keyring 设置的信息。
 
 ### **2. Cosmos 私钥（不安全）**
 
@@ -163,7 +163,7 @@ journalctl -f -u peggo
 这是一个高级 DevOps 主题，请咨询你的系统管理员。
 </Callout>
 
-在[这里](https://docs.cosmos.network/v0.46/run-node/keyring.html)了解更多关于 Cosmos Keyring 设置的信息。一旦你启动了节点，默认的 keyring 将以加密形式将验证者操作员密钥存储在磁盘上。通常，keyring 位于节点的主目录中，即 `~/.injectived/keyring-file`。
+在[这里](https://docs.cosmos.network/sdk/latest/node/keyring)了解更多关于 Cosmos Keyring 设置的信息。一旦你启动了节点，默认的 keyring 将以加密形式将验证者操作员密钥存储在磁盘上。通常，keyring 位于节点的主目录中，即 `~/.injectived/keyring-file`。
 
 Injective 质押文档的某些部分将指导你使用此密钥进行治理目的，即提交交易和设置以太坊桥接。为了保护密钥免受未授权访问，即使 keyring 密码通过配置泄露，你也可以设置操作系统权限，仅允许 `injectived` / `peggo` 进程访问磁盘。
 

--- a/.gitbook/cn/references.mdx
+++ b/.gitbook/cn/references.mdx
@@ -22,7 +22,7 @@ updatedAt: "2026-06-18"
 | [Injective TypeScript SDK](https://github.com/InjectiveLabs/injective-ts)                                 | 使用 TypeScript 在 Injective 上构建 dApp                                                                                   |
 | [Injective API Reference](https://api.injective.exchange)                                     | 面向交易者的 Injective 交互详细 API 文档                                                       |
 | [Cosmovisor](./infra/cosmovisor/)                                                 | 围绕 Cosmos SDK 二进制文件的小型进程管理器，用于监控治理模块                                        |
-| [CosmosSDK](https://docs.cosmos.network/main/build)                                          | Cosmos SDK 文档，是与 Injective 生态系统集成的开发者的宝贵资源         |
+| [CosmosSDK](https://docs.cosmos.network/sdk/latest/learn)                                          | Cosmos SDK 文档，是与 Injective 生态系统集成的开发者的宝贵资源         |
 
 ### 生态系统工具和资源
 

--- a/.gitbook/defi/tokens/inj-coin.mdx
+++ b/.gitbook/defi/tokens/inj-coin.mdx
@@ -58,7 +58,7 @@ INJ is used to govern all aspects of the chain, including:
 * Peggy Module Parameters
 * Wasmx Module Parameters
 * Software upgrades
-* Cosmos-SDK module parameters for the [auth](https://docs.cosmos.network/main/modules/auth#parameters), [bank](https://docs.cosmos.network/main/modules/bank), [crisis](https://docs.cosmos.network/main/modules/crisis), [distribution](https://docs.cosmos.network/main/modules/distribution), [gov](https://docs.cosmos.network/main/modules/gov), [mint](https://docs.cosmos.network/main/modules/mint), [slashing](https://docs.cosmos.network/main/modules/slashing), and [staking](https://docs.cosmos.network/main/modules/staking) modules.
+* Cosmos-SDK module parameters for the [auth](https://docs.cosmos.network/sdk/latest/modules/auth/auth#parameters), [bank](https://docs.cosmos.network/sdk/latest/modules/bank/README), [crisis](https://docs.cosmos.network/sdk/latest/modules/crisis/README), [distribution](https://docs.cosmos.network/sdk/latest/modules/distribution/README), [gov](https://docs.cosmos.network/sdk/latest/modules/gov/README), [mint](https://docs.cosmos.network/sdk/latest/modules/mint/README), [slashing](https://docs.cosmos.network/sdk/latest/modules/slashing/README), and [staking](https://docs.cosmos.network/sdk/latest/modules/staking/README) modules.
 
 Full details on the governance process can be found [here](https://blog.injectiveprotocol.com/injective-governance-proposal-procedure).
 

--- a/.gitbook/defi/transaction-fees.mdx
+++ b/.gitbook/defi/transaction-fees.mdx
@@ -8,7 +8,7 @@ updatedAt: "2025-10-30"
 <Callout icon="info" color="#07C1FF" iconType="regular">
 Learn about the differences between `Gas` and `Fees` on Injective.
 
-Pre-requisite Readings → [Cosmos SDK Gas](https://docs.cosmos.network/main/build/modules/auth#gas--fees)
+Pre-requisite Readings → [Cosmos SDK Gas](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers)
 </Callout>
 
 Gas represents the amount of computational effort required to execute specific operations on the state machine.
@@ -36,7 +36,7 @@ In the Cosmos SDK, gas is tracked in the main `GasMeter` and the `BlockGasMeter`
 * `GasMeter`: keeps track of the gas consumed during executions that lead to state transitions. It is reset on every transaction execution.
 * `BlockGasMeter`: keeps track of the gas consumed in a block and enforces that the gas does not go over a predefined limit. This limit is defined in the Tendermint consensus parameters and can be changed via governance parameter change proposals.
 
-More information regarding gas in Cosmos SDK can be found [here](https://docs.cosmos.network/main/learn/beginner/gas-fees).
+More information regarding gas in Cosmos SDK can be found [here](https://docs.cosmos.network/sdk/latest/learn/concepts/context-gas-events).
 
 In Cosmos, there are types of operations that are not triggered by transactions that can also result in state transitions. Concrete examples are the `BeginBlock` and `EndBlock` operations and the `AnteHandler` checks, which might also read and write to the store before running the state transition from a transaction.
 
@@ -46,4 +46,4 @@ These operations are defined by the Tendermint Core's Application Blockchain Int
 
 #### `AnteHandler`
 
-The Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/v0.45/modules/auth/03_antehandlers.html) performs basic checks prior to transaction execution. These checks are usually signature verification, transaction field validation, transaction fees, etc.
+The Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers) performs basic checks prior to transaction execution. These checks are usually signature verification, transaction field validation, transaction fees, etc.

--- a/.gitbook/defi/wallet/accounts.mdx
+++ b/.gitbook/defi/wallet/accounts.mdx
@@ -10,7 +10,7 @@ This document describes the built-in accounts system of Injective.
 
 Pre-requisite Readings:
 
-* [Cosmos SDK Accounts](https://docs.cosmos.network/main/basics/accounts)
+* [Cosmos SDK Accounts](https://docs.cosmos.network/sdk/latest/learn/concepts/accounts)
 * [Ethereum Accounts](https://ethereum.org/en/whitepaper/#ethereum-accounts)
 </Callout>
 

--- a/.gitbook/developers-native/core/auth/index.mdx
+++ b/.gitbook/developers-native/core/auth/index.mdx
@@ -139,7 +139,7 @@ message BaseAccount {
 
 ### Vesting Account
 
-See [Vesting](https://docs.cosmos.network/main/modules/auth/vesting/).
+See [Vesting](https://docs.cosmos.network/sdk/latest/modules/auth/vesting).
 
 ## AnteHandlers
 

--- a/.gitbook/developers-native/core/authz/index.mdx
+++ b/.gitbook/developers-native/core/authz/index.mdx
@@ -83,7 +83,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/x/bank/types/send_authoriz
 
 #### StakeAuthorization
 
-`StakeAuthorization` implements the `Authorization` interface for messages in the [staking module](https://docs.cosmos.network/v0.50/build/modules/staking). It takes an `AuthorizationType` to specify whether you want to authorise delegating, undelegating or redelegating (i.e. these have to be authorised separately). It also takes an optional `MaxTokens` that keeps track of a limit to the amount of tokens that can be delegated/undelegated/redelegated. If left empty, the amount is unlimited. Additionally, this Msg takes an `AllowList` or a `DenyList`, which allows you to select which validators you allow or deny grantees to stake with.
+`StakeAuthorization` implements the `Authorization` interface for messages in the [staking module](https://docs.cosmos.network/sdk/latest/modules/staking/README). It takes an `AuthorizationType` to specify whether you want to authorise delegating, undelegating or redelegating (i.e. these have to be authorised separately). It also takes an optional `MaxTokens` that keeps track of a limit to the amount of tokens that can be delegated/undelegated/redelegated. If left empty, the amount is unlimited. Additionally, this Msg takes an `AllowList` or a `DenyList`, which allows you to select which validators you allow or deny grantees to stake with.
 
 ```protobuf reference
 https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/proto/cosmos/staking/v1beta1/authz.proto#L11-L35

--- a/.gitbook/developers-native/core/circuit/index.mdx
+++ b/.gitbook/developers-native/core/circuit/index.mdx
@@ -13,20 +13,20 @@ Circuit Breaker works with the idea that an address or set of addresses have the
 
 The transactions are checked and can be rejected at two points:
 
-* In `CircuitBreakerDecorator` [ante handler](https://docs.cosmos.network/main/learn/advanced/baseapp#antehandler):
+* In `CircuitBreakerDecorator` [ante handler](https://docs.cosmos.network/sdk/latest/learn/concepts/baseapp#antehandler):
 
 ```go reference
 https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/x/circuit/ante/circuit.go#L27-L41
 ``` 
 
-* With a [message router check](https://docs.cosmos.network/main/learn/advanced/baseapp#msg-service-router):
+* With a [message router check](https://docs.cosmos.network/sdk/latest/learn/concepts/baseapp#message-routing):
 
 ```go reference
 https://github.com/cosmos/cosmos-sdk/blob/v0.50.1/baseapp/msg_service_router.go#L104-L115
 ``` 
 
 :::note
-The `CircuitBreakerDecorator` works for most use cases, but [does not check the inner messages of a transaction](https://docs.cosmos.network/main/learn/beginner/tx-lifecycle#antehandler). This some transactions (such as `x/authz` transactions or some `x/gov` transactions) may pass the ante handler. **This does not affect the circuit breaker** as the message router check will still fail the transaction.
+The `CircuitBreakerDecorator` works for most use cases, but [does not check the inner messages of a transaction](https://docs.cosmos.network/sdk/latest/learn/concepts/lifecycle#step-1-antehandler). This some transactions (such as `x/authz` transactions or some `x/gov` transactions) may pass the ante handler. **This does not affect the circuit breaker** as the message router check will still fail the transaction.
 This tradeoff is to avoid introducing more dependencies in the `x/circuit` module. Chains can re-define the `CircuitBreakerDecorator` to check for inner messages if they wish to do so.
 :::
 
@@ -105,7 +105,7 @@ Reset is called by an authorized account to enable execution for a specific msgU
 ### MsgAuthorizeCircuitBreaker
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#L25-L75
+https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L25-L40
 ```
 
 This message is expected to fail if:
@@ -115,7 +115,7 @@ This message is expected to fail if:
 ### MsgTripCircuitBreaker
 
 ```protobuf reference 
-https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#L77-L93
+https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L47-L60
 ```
 
 This message is expected to fail if:
@@ -125,7 +125,7 @@ This message is expected to fail if:
 ### MsgResetCircuitBreaker
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#L95-109
+https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L67-L78
 ```
 
 This message is expected to fail if:

--- a/.gitbook/developers-native/core/genutil/index.mdx
+++ b/.gitbook/developers-native/core/genutil/index.mdx
@@ -45,7 +45,7 @@ The genutil commands are available under the `genesis` subcommand.
 
 #### add-genesis-account
 
-Add a genesis account to `genesis.json`. Learn more [here](https://docs.cosmos.network/main/run-node/run-node#adding-genesis-accounts).
+Add a genesis account to `genesis.json`. Learn more [here](https://docs.cosmos.network/sdk/latest/node/run-node#3-add-genesis-accounts).
 
 #### collect-gentxs
 

--- a/.gitbook/developers-native/examples/authz.mdx
+++ b/.gitbook/developers-native/examples/authz.mdx
@@ -30,7 +30,7 @@ List of useful message types:
 "/injective.exchange.v1beta1.MsgWithdraw",
 ```
 
-Per [cosmos sdk docs](https://docs.cosmos.network/main/modules/authz), "Authorizations must be granted for a particular Msg service method one by one", so the following code snippet must be repeated for each message type that you would like for the `grantee` to have authorization on behalf of a `granter`.
+Per [cosmos sdk docs](https://docs.cosmos.network/sdk/latest/modules/authz/README), "Authorizations must be granted for a particular Msg service method one by one", so the following code snippet must be repeated for each message type that you would like for the `grantee` to have authorization on behalf of a `granter`.
 
 ```ts
 import { Network } from "@injectivelabs/networks";

--- a/.gitbook/developers-native/injective/evm/03_state_transitions.mdx
+++ b/.gitbook/developers-native/injective/evm/03_state_transitions.mdx
@@ -23,14 +23,14 @@ Users submit transactions client-side to broadcast it to the network. When the t
 3. The `Tx` fields are validated (stateless) using `ValidateBasic()`
 4. The `Tx` is **signed** using the key associated with the sender address and the latest ethereum hard fork (`London`, `Berlin`, etc) from the `ChainConfig`
 5. The `Tx` is **built** from the msg fields using the Cosmos Config builder
-6. The `Tx` is **broadcasted** in [sync mode](https://docs.cosmos.network/master/run-node/txs.html#broadcasting-a-transaction) to ensure to wait for a [`CheckTx`](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#intro-to-abci) execution response. Transactions are validated by the application using `CheckTx()`, before being added to the mempool of the consensus engine.
+6. The `Tx` is **broadcasted** in [sync mode](https://docs.cosmos.network/sdk/latest/node/txs#broadcasting-a-transaction) to ensure to wait for a [`CheckTx`](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#intro-to-abci) execution response. Transactions are validated by the application using `CheckTx()`, before being added to the mempool of the consensus engine.
 7. JSON-RPC user receives a response with the [`RLP`](https://eth.wiki/en/fundamentals/rlp) hash of the transaction fields. This hash is different from the default hash used by SDK Transactions that calculates the `sha256` hash of the transaction bytes.
 
 ## Server-Side
 
 Once a block (containing the `Tx`) has been committed during consensus, it is applied to the application in a series of ABCI msgs server-side.
 
-Each `Tx` is handled by the application by calling [`RunTx`](https://docs.cosmos.network/master/core/baseapp.html#runtx). After a stateless validation on each `sdk.Msg` in the `Tx`, the `AnteHandler` confirms whether the `Tx` is an Ethereum or SDK transaction. As an Ethereum transaction it's containing msgs are then handled by the `x/evm` module to update the application's state.
+Each `Tx` is handled by the application by calling [`RunTx`](https://docs.cosmos.network/sdk/latest/learn/concepts/baseapp#the-transaction-execution-pipeline). After a stateless validation on each `sdk.Msg` in the `Tx`, the `AnteHandler` confirms whether the `Tx` is an Ethereum or SDK transaction. As an Ethereum transaction it's containing msgs are then handled by the `x/evm` module to update the application's state.
 
 ### AnteHandler
 
@@ -54,7 +54,7 @@ The `anteHandler` is run for every transaction. It checks if the `Tx` is an Ethe
 - `CanTransferDecorator(evmKeeper, feeMarketKeeper)` creates an EVM from the message and calls the BlockContext CanTransfer function to see if the address can execute the transaction.
 - `EthIncrementSenderSequenceDecorator(ak)`  handles incrementing the sequence of the signer (i.e sender). If the transaction is a contract creation, the nonce will be incremented during the transaction execution and not within this AnteHandler decorator.
 
-The options `authante.NewMempoolFeeDecorator()`, `authante.NewTxTimeoutHeightDecorator()` and `authante.NewValidateMemoDecorator(ak)` are the same as for a Cosmos `Tx`. Click [here](https://docs.cosmos.network/master/basics/gas-fees.html#antehandler) for more on the `anteHandler`.
+The options `authante.NewMempoolFeeDecorator()`, `authante.NewTxTimeoutHeightDecorator()` and `authante.NewValidateMemoDecorator(ak)` are the same as for a Cosmos `Tx`. Click [here](https://docs.cosmos.network/sdk/latest/learn/concepts/context-gas-events) for more on the `anteHandler`.
 
 ### EVM module
 

--- a/.gitbook/developers-native/injective/evm/05_abci.mdx
+++ b/.gitbook/developers-native/injective/evm/05_abci.mdx
@@ -3,7 +3,7 @@ title: Application Blockchain Interface (ABCI)
 updatedAt: "2025-12-10"
 ---
 
-The Application Blockchain Interface (ABCI) allows the application to interact with the Tendermint Consensus engine. The application maintains several separate ABCI connections with Tendermint. The most relevant for the  `x/evm` is the [Consensus connection at Commit](https://docs.tendermint.com/v0.35/spec/abci/apps.html#consensus-connection). This connection is responsible for block execution and calls the fuctions `InitChain` (containing `InitGenesis`), `BeginBlock`, `DeliverTx`, `EndBlock`, `Commit` . `InitChain` is only called the first time a new blockchain is started and `DeliverTx` is called for each transaction in the block.
+The Application Blockchain Interface (ABCI) allows the application to interact with the Tendermint Consensus engine. The application maintains several separate ABCI connections with Tendermint. The most relevant for the  `x/evm` is the [Consensus connection at Commit](https://docs.cosmos.network/cometbft/latest/spec/abci/Methods). This connection is responsible for block execution and calls the fuctions `InitChain` (containing `InitGenesis`), `BeginBlock`, `DeliverTx`, `EndBlock`, `Commit` . `InitChain` is only called the first time a new blockchain is started and `DeliverTx` is called for each transaction in the block.
 
 ## InitGenesis
 

--- a/.gitbook/developers-native/injective/wasmx/01_concepts.mdx
+++ b/.gitbook/developers-native/injective/wasmx/01_concepts.mdx
@@ -35,7 +35,7 @@ A contract can be deactivated automatically if it runs out of gas, or manually b
 
 ### Fee Grant
 
-The Wasmx module allows other addresses (contracts, EOAs) to pay for the Begin blocker execution of other contracts through the [`x/feegrant`](https://docs.cosmos.network/main/modules/feegrant) module.
+The Wasmx module allows other addresses (contracts, EOAs) to pay for the Begin blocker execution of other contracts through the [`x/feegrant`](https://docs.cosmos.network/sdk/latest/modules/feegrant/README) module.
 
 When a contract is being registered for the first time, users specify the `FundingMode` which indicates how the contract's execution will be funded. Three modes are supported:
 

--- a/.gitbook/developers-native/transactions.mdx
+++ b/.gitbook/developers-native/transactions.mdx
@@ -3,7 +3,7 @@ title: Transactions
 updatedAt: "2025-10-30"
 ---
 
-_Pre-requisite reading:_ [Cosmos SDK Transactions](https://docs.cosmos.network/main/learn/advanced/transactions)
+_Pre-requisite reading:_ [Cosmos SDK Transactions](https://docs.cosmos.network/sdk/latest/learn/concepts/transactions)
 
 State changes on Injective can be done through transactions. Users create transactions, sign them and broadcast them to Injective.
 

--- a/.gitbook/developers-native/transactions/web3-gateway.mdx
+++ b/.gitbook/developers-native/transactions/web3-gateway.mdx
@@ -3,7 +3,7 @@ title: Web3 Gateway Transaction
 updatedAt: "2025-10-30"
 ---
 
-_Pre-requisite reading #1:_ [Transaction Lifecycle](https://docs.cosmos.network/main/basics/tx-lifecycle)
+_Pre-requisite reading #1:_ [Transaction Lifecycle](https://docs.cosmos.network/sdk/latest/learn/concepts/lifecycle)
 
 _Pre-requisite reading #2:_ Transactions on Injective
 

--- a/.gitbook/developers-native/wallets/offchain-data.mdx
+++ b/.gitbook/developers-native/wallets/offchain-data.mdx
@@ -3,7 +3,7 @@ title: Offchain (Arbitrary) Data
 updatedAt: "2025-11-28"
 ---
 
-On this page, we'll provide an example of how to sign and verify arbitrary data as per the [ADR-036](https://docs.cosmos.network/main/build/architecture/adr-036-arbitrary-signature) specification on Cosmos.
+On this page, we'll provide an example of how to sign and verify arbitrary data as per the [ADR-036](https://docs.cosmos.network/sdk/latest/reference/architecture/adr-036-arbitrary-signature) specification on Cosmos.
 
 <Callout icon="info" color="#07C1FF" iconType="regular">
 You can use the `generateArbitrarySignDoc` function from `@injectivelabs/sdk-ts` to generate ADR-36 compatible `signDoc`. You can then use it to sign/verify using a browser wallet or in a CLI environment. Make sure you are using the latest package versions.

--- a/.gitbook/infra/validator-mainnet/peggo.mdx
+++ b/.gitbook/infra/validator-mainnet/peggo.mdx
@@ -186,7 +186,7 @@ Please note that the default keyring backend is `file` and that as such peggo wi
 
 To use the default injectived key configuration, you should set the keyring path to the home directory of your injectived node, e.g., `~/.injectived`.
 
-You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html).
+You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/sdk/latest/node/keyring).
 
 #### **Option 2. Cosmos Private Key (Unsafe)**
 
@@ -282,7 +282,7 @@ journalctl -f -u peggo
 This is an advanced DevOps topic, consult with your sysadmin.
 </Callout>
 
-Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
+Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/sdk/latest/node/keyring). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
 
 Some sections of the Injective Staking documentation will guide you through using this key for governance purposes, i.e. submitting transactions and setting up an Ethereum bridge. In order to protect the keys from unauthorized access, even when the keyring passphrase is leaked via configs, you can set OS permissions to allow disk access to `injectived` / `peggo` processes only.
 

--- a/.gitbook/infra/validator-testnet/peggo.mdx
+++ b/.gitbook/infra/validator-testnet/peggo.mdx
@@ -29,7 +29,7 @@ Update the `PEGGO_COSMOS_FROM` to your validator key name (or account address) a
 
 Keyring path must be pointing to homedir of your injectived node, if you want reuse the keys from there.
 
-Learn more about Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html).
+Learn more about Keyring setup [here](https://docs.cosmos.network/sdk/latest/node/keyring).
 
 ### **2. Cosmos Private Key (Unsafe)**
 
@@ -163,7 +163,7 @@ journalctl -f -u peggo
 This is an advanced DevOps topic, consult with your sysadmin.
 </Callout>
 
-Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually, the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
+Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/sdk/latest/node/keyring). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually, the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
 
 Some sections of the Injective Staking documentation will guide you through using this key for governance purposes, i.e., submitting transactions and setting up an Ethereum bridge. In order to protect the keys from unauthorized access, even when the keyring passphrase is leaked via configs, you can set OS permissions to allow disk access to `injectived` / `peggo` processes only.
 
@@ -244,7 +244,7 @@ Please note that the default keyring backend is `file` and that, as such, peggo 
 
 To use the default injectived key configuration, you should set the keyring path to the home directory of your injectived node, e.g. `~/.injectived`.
 
-You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html).
+You can also read more about the Cosmos Keyring setup [here](https://docs.cosmos.network/sdk/latest/node/keyring).
 
 #### **Option 2. Cosmos Private Key (Unsafe)**
 
@@ -390,7 +390,7 @@ journalctl -f -u peggo
 This is an advanced DevOps topic, consult with your sysadmin.
 </Callout>
 
-Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/v0.46/run-node/keyring.html). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually, the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
+Learn more about Cosmos Keyring setup [here](https://docs.cosmos.network/sdk/latest/node/keyring). Once you've launched your node, the default keyring will have the validator operator key stored on disk in the encrypted form. Usually, the keyring is located within node's homedir, i.e. `~/.injectived/keyring-file`.
 
 Some sections of the Injective Staking documentation will guide you through using this key for governance purposes, i.e., submitting transactions and setting up an Ethereum bridge. In order to protect the keys from unauthorized access, even when the keyring passphrase is leaked via configs, you can set OS permissions to allow disk access to `injectived` / `peggo` processes only.
 

--- a/.gitbook/jp/defi/tokens/inj-coin.mdx
+++ b/.gitbook/jp/defi/tokens/inj-coin.mdx
@@ -47,7 +47,7 @@ INJは、以下を含むチェーンのすべての側面をガバナンスす�
 * Peggyモジュールパラメータ
 * Wasmxモジュールパラメータ
 * ソフトウェアアップグレード
-* Cosmos-SDKモジュールパラメータ（[auth](https://docs.cosmos.network/main/modules/auth#parameters)、[bank](https://docs.cosmos.network/main/modules/bank)、[crisis](https://docs.cosmos.network/main/modules/crisis)、[distribution](https://docs.cosmos.network/main/modules/distribution)、[gov](https://docs.cosmos.network/main/modules/gov)、[mint](https://docs.cosmos.network/main/modules/mint)、[slashing](https://docs.cosmos.network/main/modules/slashing)、[staking](https://docs.cosmos.network/main/modules/staking)モジュール）
+* Cosmos-SDKモジュールパラメータ（[auth](https://docs.cosmos.network/sdk/latest/modules/auth/auth#parameters)、[bank](https://docs.cosmos.network/sdk/latest/modules/bank/README)、[crisis](https://docs.cosmos.network/sdk/latest/modules/crisis/README)、[distribution](https://docs.cosmos.network/sdk/latest/modules/distribution/README)、[gov](https://docs.cosmos.network/sdk/latest/modules/gov/README)、[mint](https://docs.cosmos.network/sdk/latest/modules/mint/README)、[slashing](https://docs.cosmos.network/sdk/latest/modules/slashing/README)、[staking](https://docs.cosmos.network/sdk/latest/modules/staking/README)モジュール）
 
 ガバナンスプロセスの詳細については、[こちら](https://blog.injectiveprotocol.com/injective-governance-proposal-procedure)をご覧ください。
 

--- a/.gitbook/jp/defi/transaction-fees.mdx
+++ b/.gitbook/jp/defi/transaction-fees.mdx
@@ -7,7 +7,7 @@ title: GasとFee
 <Callout icon="info" color="#07C1FF" iconType="regular">
 Injectiveにおける`Gas`と`Fee`の違いについて学びましょう。
 
-前提知識 → [Cosmos SDK Gas](https://docs.cosmos.network/main/build/modules/auth#gas--fees)
+前提知識 → [Cosmos SDK Gas](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers)
 </Callout>
 
 Gasは、ステートマシン上で特定の操作を実行するために必要な計算量を表します。
@@ -35,7 +35,7 @@ Cosmos SDKでは、Gasはメインの`GasMeter`と`BlockGasMeter`で追跡され
 * `GasMeter`：状態遷移の実行中に消費されたGasを追跡します。トランザクション実行ごとにリセットされます。
 * `BlockGasMeter`：ブロック内で消費されたGasを追跡し、Gasが事前に定義された制限を超えないようにします。この制限はTendermintコンセンサスパラメーターで定義され、ガバナンスパラメーター変更プロポーザルを通じて変更できます。
 
-Cosmos SDKにおけるGasの詳細については、[こちら](https://docs.cosmos.network/main/learn/beginner/gas-fees)をご覧ください。
+Cosmos SDKにおけるGasの詳細については、[こちら](https://docs.cosmos.network/sdk/latest/learn/concepts/context-gas-events)をご覧ください。
 
 Cosmosでは、トランザクションによってトリガーされない操作でも状態遷移を引き起こすことがあります。具体的な例としては、`BeginBlock`と`EndBlock`の操作、およびトランザクションからの状態遷移を実行する前にストアの読み取りと書き込みを行う可能性のある`AnteHandler`チェックがあります。
 
@@ -45,4 +45,4 @@ Cosmosでは、トランザクションによってトリガーされない操�
 
 #### `AnteHandler`
 
-Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/v0.45/modules/auth/03_antehandlers.html)は、トランザクション実行前に基本的なチェックを行います。これらのチェックは通常、署名検証、トランザクションフィールドの検証、トランザクション手数料の検証・徴収などです。
+Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers)は、トランザクション実行前に基本的なチェックを行います。これらのチェックは通常、署名検証、トランザクションフィールドの検証、トランザクション手数料の検証・徴収などです。

--- a/.gitbook/jp/defi/wallet/accounts.mdx
+++ b/.gitbook/jp/defi/wallet/accounts.mdx
@@ -9,7 +9,7 @@ title: アカウント
 
 前提知識：
 
-* [Cosmos SDK Accounts](https://docs.cosmos.network/main/basics/accounts)
+* [Cosmos SDK Accounts](https://docs.cosmos.network/sdk/latest/learn/concepts/accounts)
 * [Ethereum Accounts](https://ethereum.org/en/whitepaper/#ethereum-accounts)
 </Callout>
 

--- a/.gitbook/jp/developers-native/examples/authz.mdx
+++ b/.gitbook/jp/developers-native/examples/authz.mdx
@@ -30,7 +30,7 @@ updatedAt: "2025-12-23"
 "/injective.exchange.v1beta1.MsgWithdraw",
 ```
 
-[cosmos sdkのドキュメント](https://docs.cosmos.network/main/modules/authz)によると、「認可は特定のMsgサービスメソッドごとに1つずつ付与される必要がある」とされています。したがって、`grantee`が`granter`に代わって認可を持つようにしたい各メッセージ型ごとに、以下のコードスニペットを繰り返す必要があります。
+[cosmos sdkのドキュメント](https://docs.cosmos.network/sdk/latest/modules/authz/README)によると、「認可は特定のMsgサービスメソッドごとに1つずつ付与される必要がある」とされています。したがって、`grantee`が`granter`に代わって認可を持つようにしたい各メッセージ型ごとに、以下のコードスニペットを繰り返す必要があります。
 
 ```ts
 import { Network } from "@injectivelabs/networks";

--- a/.gitbook/jp/developers-native/transactions/web3-gateway.mdx
+++ b/.gitbook/jp/developers-native/transactions/web3-gateway.mdx
@@ -3,7 +3,7 @@ title: Web3 Gatewayトランザクション
 updatedAt: "2025-10-30"
 ---
 
-_事前必読 #1:_ [Transaction Lifecycle](https://docs.cosmos.network/main/basics/tx-lifecycle)
+_事前必読 #1:_ [Transaction Lifecycle](https://docs.cosmos.network/sdk/latest/learn/concepts/lifecycle)
 
 _事前必読 #2:_ Injective上のトランザクション
 

--- a/.gitbook/jp/developers-native/wallets/offchain-data.mdx
+++ b/.gitbook/jp/developers-native/wallets/offchain-data.mdx
@@ -3,7 +3,7 @@ title: オフチェーン（任意）データ
 updatedAt: "2025-11-28"
 ---
 
-このページでは、Cosmosの[ADR-036](https://docs.cosmos.network/main/build/architecture/adr-036-arbitrary-signature)仕様に基づいて任意のデータに署名・検証する方法の例を提供します。
+このページでは、Cosmosの[ADR-036](https://docs.cosmos.network/sdk/latest/reference/architecture/adr-036-arbitrary-signature)仕様に基づいて任意のデータに署名・検証する方法の例を提供します。
 
 <Callout icon="info" color="#07C1FF" iconType="regular">
 `@injectivelabs/sdk-ts`の`generateArbitrarySignDoc`関数を使用してADR-36互換の`signDoc`を生成できます。生成した`signDoc`をブラウザウォレットまたはCLI環境での署名・検証に使用できます。最新のパッケージバージョンを使用していることを確認してください。

--- a/.gitbook/jp/references.mdx
+++ b/.gitbook/jp/references.mdx
@@ -22,7 +22,7 @@ Injectiveでの開発を始めるための開発者ツールとリソース
 | [Injective TypeScript SDK](https://github.com/InjectiveLabs/injective-ts)                                 | TypeScriptを使用してInjective上でdAppを構築                                                                                   |
 | [Injective API Reference](https://api.injective.exchange)                                     | トレーダー向けに、Injectiveの各種操作APIをまとめた詳細リファレンス                                                       |
 | [Cosmovisor](./infra/cosmovisor/)                                                 | ガバナンスモジュールを監視するCosmos SDKバイナリ周辺の小さなプロセスマネージャー                                        |
-| [CosmosSDK](https://docs.cosmos.network/main/build)                                          | Injectiveエコシステムと統合する開発者にとって貴重なリソースとなるCosmos SDKドキュメント         |
+| [CosmosSDK](https://docs.cosmos.network/sdk/latest/learn)                                          | Injectiveエコシステムと統合する開発者にとって貴重なリソースとなるCosmos SDKドキュメント         |
 
 ### エコシステムツールとリソース
 

--- a/.gitbook/ko/defi/tokens/inj-coin.mdx
+++ b/.gitbook/ko/defi/tokens/inj-coin.mdx
@@ -48,7 +48,7 @@ INJ는 다음을 포함한 체인의 모든 측면을 관리하는 데 사용됩
 * Peggy 모듈 파라미터
 * Wasmx 모듈 파라미터
 * 소프트웨어 업그레이드
-* [auth](https://docs.cosmos.network/main/modules/auth#parameters), [bank](https://docs.cosmos.network/main/modules/bank), [crisis](https://docs.cosmos.network/main/modules/crisis), [distribution](https://docs.cosmos.network/main/modules/distribution), [gov](https://docs.cosmos.network/main/modules/gov), [mint](https://docs.cosmos.network/main/modules/mint), [slashing](https://docs.cosmos.network/main/modules/slashing), [staking](https://docs.cosmos.network/main/modules/staking) 모듈의 Cosmos-SDK 모듈 파라미터.
+* [auth](https://docs.cosmos.network/sdk/latest/modules/auth/auth#parameters), [bank](https://docs.cosmos.network/sdk/latest/modules/bank/README), [crisis](https://docs.cosmos.network/sdk/latest/modules/crisis/README), [distribution](https://docs.cosmos.network/sdk/latest/modules/distribution/README), [gov](https://docs.cosmos.network/sdk/latest/modules/gov/README), [mint](https://docs.cosmos.network/sdk/latest/modules/mint/README), [slashing](https://docs.cosmos.network/sdk/latest/modules/slashing/README), [staking](https://docs.cosmos.network/sdk/latest/modules/staking/README) 모듈의 Cosmos-SDK 모듈 파라미터.
 
 거버넌스 프로세스에 대한 전체 세부 정보는 [여기](https://blog.injectiveprotocol.com/injective-governance-proposal-procedure)에서 찾을 수 있습니다.
 

--- a/.gitbook/ko/defi/transaction-fees.mdx
+++ b/.gitbook/ko/defi/transaction-fees.mdx
@@ -8,7 +8,7 @@ updatedAt: "2026-02-24"
 <Callout icon="info" color="#07C1FF" iconType="regular">
 Injective에서 `Gas`와 `Fees`의 차이점에 대해 알아보세요.
 
-사전 필수 읽기 → [Cosmos SDK Gas](https://docs.cosmos.network/main/build/modules/auth#gas--fees)
+사전 필수 읽기 → [Cosmos SDK Gas](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers)
 </Callout>
 
 가스는 상태 머신에서 특정 작업을 실행하는 데 필요한 계산 노력의 양을 나타냅니다.
@@ -36,7 +36,7 @@ Cosmos SDK에서 가스는 메인 `GasMeter`와 `BlockGasMeter`에서 추적됩�
 * `GasMeter`: 상태 전환으로 이어지는 실행 중에 소비된 가스를 추적합니다. 모든 트랜잭션 실행 시 재설정됩니다.
 * `BlockGasMeter`: 블록에서 소비된 가스를 추적하고 가스가 미리 정의된 한도를 초과하지 않도록 합니다. 이 한도는 Tendermint 합의 파라미터에 정의되어 있으며 거버넌스 파라미터 변경 제안을 통해 변경할 수 있습니다.
 
-Cosmos SDK의 가스에 대한 자세한 정보는 [여기](https://docs.cosmos.network/main/learn/beginner/gas-fees)에서 찾을 수 있습니다.
+Cosmos SDK의 가스에 대한 자세한 정보는 [여기](https://docs.cosmos.network/sdk/latest/learn/concepts/context-gas-events)에서 찾을 수 있습니다.
 
 Cosmos에는 트랜잭션에 의해 트리거되지 않지만 상태 전환을 초래할 수 있는 작업 유형이 있습니다. 구체적인 예로는 `BeginBlock` 및 `EndBlock` 작업과 트랜잭션에서 상태 전환을 실행하기 전에 스토어에 읽고 쓸 수 있는 `AnteHandler` 검사가 있습니다.
 
@@ -46,4 +46,4 @@ Cosmos에는 트랜잭션에 의해 트리거되지 않지만 상태 전환을 �
 
 #### `AnteHandler`
 
-Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/v0.45/modules/auth/03_antehandlers.html)는 트랜잭션 실행 전에 기본 검사를 수행합니다. 이러한 검사는 일반적으로 서명 검증, 트랜잭션 필드 검증, 트랜잭션 수수료 등입니다.
+Cosmos SDK [`AnteHandler`](https://docs.cosmos.network/sdk/latest/modules/auth/auth#antehandlers)는 트랜잭션 실행 전에 기본 검사를 수행합니다. 이러한 검사는 일반적으로 서명 검증, 트랜잭션 필드 검증, 트랜잭션 수수료 등입니다.

--- a/.gitbook/ko/defi/wallet/accounts.mdx
+++ b/.gitbook/ko/defi/wallet/accounts.mdx
@@ -10,7 +10,7 @@ updatedAt: "2026-02-24"
 
 사전 필수 읽기:
 
-* [Cosmos SDK Accounts](https://docs.cosmos.network/main/basics/accounts)
+* [Cosmos SDK Accounts](https://docs.cosmos.network/sdk/latest/learn/concepts/accounts)
 * [Ethereum Accounts](https://ethereum.org/en/whitepaper/#ethereum-accounts)
 </Callout>
 

--- a/.gitbook/ko/developers-native/core/circuit.mdx
+++ b/.gitbook/ko/developers-native/core/circuit.mdx
@@ -13,20 +13,20 @@ Circuit Breaker는 주소 또는 주소 집합이 메시지 실행 및/또는 me
 
 트랜잭션은 두 지점에서 확인되고 거부될 수 있습니다:
 
-* `CircuitBreakerDecorator` [ante handler](https://docs.cosmos.network/main/learn/advanced/baseapp#antehandler)에서:
+* `CircuitBreakerDecorator` [ante handler](https://docs.cosmos.network/sdk/latest/learn/concepts/baseapp#antehandler)에서:
 
 ```go reference
 https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/x/circuit/ante/circuit.go#L27-L41
 ```
 
-* [message router check](https://docs.cosmos.network/main/learn/advanced/baseapp#msg-service-router)를 통해:
+* [message router check](https://docs.cosmos.network/sdk/latest/learn/concepts/baseapp#message-routing)를 통해:
 
 ```go reference
 https://github.com/cosmos/cosmos-sdk/blob/v0.50.1/baseapp/msg_service_router.go#L104-L115
 ```
 
 :::note
-`CircuitBreakerDecorator`는 대부분의 사용 사례에서 작동하지만, [트랜잭션의 내부 메시지를 확인하지 않습니다](https://docs.cosmos.network/main/learn/beginner/tx-lifecycle#antehandler). 따라서 일부 트랜잭션(`x/authz` 트랜잭션 또는 일부 `x/gov` 트랜잭션 등)은 ante handler를 통과할 수 있습니다. **이것은 circuit breaker에 영향을 미치지 않습니다.** message router check가 여전히 트랜잭션을 실패시키기 때문입니다.
+`CircuitBreakerDecorator`는 대부분의 사용 사례에서 작동하지만, [트랜잭션의 내부 메시지를 확인하지 않습니다](https://docs.cosmos.network/sdk/latest/learn/concepts/lifecycle#step-1-antehandler). 따라서 일부 트랜잭션(`x/authz` 트랜잭션 또는 일부 `x/gov` 트랜잭션 등)은 ante handler를 통과할 수 있습니다. **이것은 circuit breaker에 영향을 미치지 않습니다.** message router check가 여전히 트랜잭션을 실패시키기 때문입니다.
 이 트레이드오프는 `x/circuit` 모듈에 더 많은 의존성을 도입하지 않기 위함입니다. 체인은 원하는 경우 내부 메시지를 확인하도록 `CircuitBreakerDecorator`를 재정의할 수 있습니다.
 :::
 
@@ -102,7 +102,7 @@ Reset은 이전에 비활성화된 메시지의 특정 msgURL에 대한 실행�
 ### MsgAuthorizeCircuitBreaker
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#L25-L75
+https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L25-L40
 ```
 
 이 메시지는 다음과 같은 경우에 실패할 것으로 예상됩니다:
@@ -112,7 +112,7 @@ https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#
 ### MsgTripCircuitBreaker
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#L77-L93
+https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L47-L60
 ```
 
 이 메시지는 다음과 같은 경우에 실패할 것으로 예상됩니다:
@@ -122,7 +122,7 @@ https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#
 ### MsgResetCircuitBreaker
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/circuit/v1/tx.proto#L95-109
+https://github.com/cosmos/cosmos-sdk/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L67-L78
 ```
 
 이 메시지는 다음과 같은 경우에 실패할 것으로 예상됩니다:

--- a/.gitbook/ko/developers-native/core/genutil.mdx
+++ b/.gitbook/ko/developers-native/core/genutil.mdx
@@ -45,7 +45,7 @@ genutil 명령어는 `genesis` 하위 명령어 아래에서 사용할 수 있�
 
 #### add-genesis-account
 
-`genesis.json`에 genesis 계정을 추가합니다. 자세한 내용은 [여기](https://docs.cosmos.network/main/run-node/run-node#adding-genesis-accounts)를 참조하세요.
+`genesis.json`에 genesis 계정을 추가합니다. 자세한 내용은 [여기](https://docs.cosmos.network/sdk/latest/node/run-node#3-add-genesis-accounts)를 참조하세요.
 
 #### collect-gentxs
 

--- a/.gitbook/ko/developers-native/examples/authz.mdx
+++ b/.gitbook/ko/developers-native/examples/authz.mdx
@@ -30,7 +30,7 @@ updatedAt: "2026-03-06"
 "/injective.exchange.v1beta1.MsgWithdraw",
 ```
 
-[cosmos sdk 문서](https://docs.cosmos.network/main/modules/authz)에 따르면 "권한은 특정 Msg 서비스 메서드에 대해 하나씩 부여되어야 합니다". 따라서 `granter`를 대신하여 `grantee`가 권한을 갖기를 원하는 각 메시지 유형에 대해 다음 코드 스니펫을 반복해야 합니다.
+[cosmos sdk 문서](https://docs.cosmos.network/sdk/latest/modules/authz/README)에 따르면 "권한은 특정 Msg 서비스 메서드에 대해 하나씩 부여되어야 합니다". 따라서 `granter`를 대신하여 `grantee`가 권한을 갖기를 원하는 각 메시지 유형에 대해 다음 코드 스니펫을 반복해야 합니다.
 
 ```ts
 import { Network } from "@injectivelabs/networks";

--- a/.gitbook/ko/developers-native/injective/evm/03_state_transitions.mdx
+++ b/.gitbook/ko/developers-native/injective/evm/03_state_transitions.mdx
@@ -23,14 +23,14 @@ updatedAt: "2026-03-07"
 3. `Tx` 필드는 `ValidateBasic()`을 사용하여 (상태 비저장) 검증됩니다
 4. `Tx`는 sender 주소와 연결된 키와 `ChainConfig`의 최신 ethereum 하드 포크(`London`, `Berlin` 등)를 사용하여 **서명**됩니다
 5. `Tx`는 Cosmos Config builder를 사용하여 msg 필드에서 **빌드**됩니다
-6. `Tx`는 [`CheckTx`](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#intro-to-abci) 실행 응답을 기다리기 위해 [sync mode](https://docs.cosmos.network/master/run-node/txs.html#broadcasting-a-transaction)로 **브로드캐스트**됩니다. 트랜잭션은 합의 엔진의 mempool에 추가되기 전에 `CheckTx()`를 사용하여 애플리케이션에 의해 검증됩니다.
+6. `Tx`는 [`CheckTx`](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#intro-to-abci) 실행 응답을 기다리기 위해 [sync mode](https://docs.cosmos.network/sdk/latest/node/txs#broadcasting-a-transaction)로 **브로드캐스트**됩니다. 트랜잭션은 합의 엔진의 mempool에 추가되기 전에 `CheckTx()`를 사용하여 애플리케이션에 의해 검증됩니다.
 7. JSON-RPC 사용자는 트랜잭션 필드의 [`RLP`](https://eth.wiki/en/fundamentals/rlp) hash가 포함된 응답을 받습니다. 이 hash는 트랜잭션 바이트의 `sha256` hash를 계산하는 SDK 트랜잭션에서 사용하는 기본 hash와 다릅니다.
 
 ## Server-Side
 
 트랜잭션을 포함하는 블록이 합의 중에 커밋되면 일련의 ABCI 메시지로 서버 측 애플리케이션에 적용됩니다.
 
-각 `Tx`는 [`RunTx`](https://docs.cosmos.network/master/core/baseapp.html#runtx)를 호출하여 애플리케이션에서 처리됩니다. `Tx`의 각 `sdk.Msg`에 대한 상태 비저장 검증 후 `AnteHandler`는 `Tx`가 Ethereum 트랜잭션인지 SDK 트랜잭션인지 확인합니다. Ethereum 트랜잭션으로서 포함된 메시지는 애플리케이션의 상태를 업데이트하기 위해 `x/evm` 모듈에서 처리됩니다.
+각 `Tx`는 [`RunTx`](https://docs.cosmos.network/sdk/latest/learn/concepts/baseapp#the-transaction-execution-pipeline)를 호출하여 애플리케이션에서 처리됩니다. `Tx`의 각 `sdk.Msg`에 대한 상태 비저장 검증 후 `AnteHandler`는 `Tx`가 Ethereum 트랜잭션인지 SDK 트랜잭션인지 확인합니다. Ethereum 트랜잭션으로서 포함된 메시지는 애플리케이션의 상태를 업데이트하기 위해 `x/evm` 모듈에서 처리됩니다.
 
 ### AnteHandler
 
@@ -54,7 +54,7 @@ updatedAt: "2026-03-07"
 - `CanTransferDecorator(evmKeeper, feeMarketKeeper)`는 메시지에서 EVM을 생성하고 BlockContext CanTransfer 함수를 호출하여 주소가 트랜잭션을 실행할 수 있는지 확인합니다.
 - `EthIncrementSenderSequenceDecorator(ak)`는 signer(즉, sender)의 시퀀스 증가를 처리합니다. 트랜잭션이 컨트랙트 생성인 경우 nonce는 이 AnteHandler decorator 내에서가 아니라 트랜잭션 실행 중에 증가합니다.
 
-`authante.NewMempoolFeeDecorator()`, `authante.NewTxTimeoutHeightDecorator()` 및 `authante.NewValidateMemoDecorator(ak)` 옵션은 Cosmos `Tx`의 경우와 동일합니다. `anteHandler`에 대한 자세한 내용은 [여기](https://docs.cosmos.network/master/basics/gas-fees.html#antehandler)를 클릭하십시오.
+`authante.NewMempoolFeeDecorator()`, `authante.NewTxTimeoutHeightDecorator()` 및 `authante.NewValidateMemoDecorator(ak)` 옵션은 Cosmos `Tx`의 경우와 동일합니다. `anteHandler`에 대한 자세한 내용은 [여기](https://docs.cosmos.network/sdk/latest/learn/concepts/context-gas-events)를 클릭하십시오.
 
 ### EVM module
 

--- a/.gitbook/ko/developers-native/injective/evm/05_abci.mdx
+++ b/.gitbook/ko/developers-native/injective/evm/05_abci.mdx
@@ -3,7 +3,7 @@ title: Application Blockchain Interface (ABCI)
 updatedAt: "2026-03-07"
 ---
 
-Application Blockchain Interface (ABCI)를 통해 애플리케이션은 Tendermint Core Consensus 엔진과 상호 작용할 수 있습니다. 애플리케이션은 Tendermint와 여러 개의 별도 ABCI 연결을 유지합니다. `x/evm`과 가장 관련이 있는 것은 [Commit에서의 Consensus 연결](https://docs.tendermint.com/v0.35/spec/abci/apps.html#consensus-connection)입니다. 이 연결은 블록 실행을 담당하며 `InitChain`(`InitGenesis` 포함), `BeginBlock`, `DeliverTx`, `EndBlock`, `Commit` 함수를 호출합니다. `InitChain`은 새 블록체인이 처음 시작될 때만 호출되고 `DeliverTx`는 블록의 각 트랜잭션에 대해 호출됩니다.
+Application Blockchain Interface (ABCI)를 통해 애플리케이션은 Tendermint Core Consensus 엔진과 상호 작용할 수 있습니다. 애플리케이션은 Tendermint와 여러 개의 별도 ABCI 연결을 유지합니다. `x/evm`과 가장 관련이 있는 것은 [Commit에서의 Consensus 연결](https://docs.cosmos.network/cometbft/latest/spec/abci/Methods)입니다. 이 연결은 블록 실행을 담당하며 `InitChain`(`InitGenesis` 포함), `BeginBlock`, `DeliverTx`, `EndBlock`, `Commit` 함수를 호출합니다. `InitChain`은 새 블록체인이 처음 시작될 때만 호출되고 `DeliverTx`는 블록의 각 트랜잭션에 대해 호출됩니다.
 
 ## InitGenesis
 

--- a/.gitbook/ko/developers-native/injective/wasmx/01_concepts.mdx
+++ b/.gitbook/ko/developers-native/injective/wasmx/01_concepts.mdx
@@ -35,7 +35,7 @@ updatedAt: "2026-03-07"
 
 ### Fee Grant
 
-Wasmx 모듈은 [`x/feegrant`](https://docs.cosmos.network/main/modules/feegrant) 모듈을 통해 다른 주소(컨트랙트, EOA)가 다른 컨트랙트의 Begin blocker 실행 비용을 지불할 수 있도록 합니다.
+Wasmx 모듈은 [`x/feegrant`](https://docs.cosmos.network/sdk/latest/modules/feegrant/README) 모듈을 통해 다른 주소(컨트랙트, EOA)가 다른 컨트랙트의 Begin blocker 실행 비용을 지불할 수 있도록 합니다.
 
 컨트랙트가 처음 등록될 때, 사용자는 컨트랙트의 실행이 어떻게 자금 지원될지를 나타내는 `FundingMode`를 지정합니다. 세 가지 모드가 지원됩니다:
 

--- a/.gitbook/ko/developers-native/transactions/web3-gateway.mdx
+++ b/.gitbook/ko/developers-native/transactions/web3-gateway.mdx
@@ -3,7 +3,7 @@ title: Web3 Gateway 트랜잭션
 updatedAt: "2026-03-06"
 ---
 
-_사전 필수 읽기 #1:_ [트랜잭션 라이프사이클](https://docs.cosmos.network/main/basics/tx-lifecycle)
+_사전 필수 읽기 #1:_ [트랜잭션 라이프사이클](https://docs.cosmos.network/sdk/latest/learn/concepts/lifecycle)
 
 _사전 필수 읽기 #2:_ Injective의 트랜잭션
 

--- a/.gitbook/ko/developers-native/wallets/offchain-data.mdx
+++ b/.gitbook/ko/developers-native/wallets/offchain-data.mdx
@@ -3,7 +3,7 @@ title: 오프체인 (임의) 데이터
 updatedAt: "2026-03-06"
 ---
 
-이 페이지에서는 Cosmos의 [ADR-036](https://docs.cosmos.network/main/build/architecture/adr-036-arbitrary-signature) 사양에 따라 임의 데이터를 서명하고 검증하는 방법의 예시를 제공합니다.
+이 페이지에서는 Cosmos의 [ADR-036](https://docs.cosmos.network/sdk/latest/reference/architecture/adr-036-arbitrary-signature) 사양에 따라 임의 데이터를 서명하고 검증하는 방법의 예시를 제공합니다.
 
 <Callout icon="info" color="#07C1FF" iconType="regular">
 `@injectivelabs/sdk-ts`의 `generateArbitrarySignDoc` 함수를 사용하여 ADR-36 호환 `signDoc`을 생성할 수 있습니다. 그런 다음 브라우저 지갑이나 CLI 환경에서 서명/검증에 사용할 수 있습니다. 최신 패키지 버전을 사용하고 있는지 확인하세요.

--- a/.gitbook/ko/infra/validator-mainnet/peggo.mdx
+++ b/.gitbook/ko/infra/validator-mainnet/peggo.mdx
@@ -127,7 +127,7 @@ injectived tx bank send $VALIDATOR_KEY_NAME $ORCHESTRATOR_INJ_ADDRESS <amount-in
 
 `.env` 파일에서 `PEGGO_COSMOS_FROM`과 `PEGGO_COSMOS_FROM_PASSPHRASE`를 지정합니다.
 
-Cosmos Keyring 설정에 대해 [여기](https://docs.cosmos.network/v0.46/run-node/keyring.html)에서 자세히 읽을 수 있습니다.
+Cosmos Keyring 설정에 대해 [여기](https://docs.cosmos.network/sdk/latest/node/keyring)에서 자세히 읽을 수 있습니다.
 
 #### **옵션 2. Cosmos Private Key (안전하지 않음)**
 
@@ -186,7 +186,7 @@ journalctl -f -u peggo
 이것은 고급 DevOps 주제입니다. 시스템 관리자와 상담하세요.
 </Callout>
 
-Cosmos Keyring 설정에 대해 [여기](https://docs.cosmos.network/v0.46/run-node/keyring.html)에서 자세히 알아보세요.
+Cosmos Keyring 설정에 대해 [여기](https://docs.cosmos.network/sdk/latest/node/keyring)에서 자세히 알아보세요.
 
 ### 기여
 

--- a/.gitbook/ko/infra/validator-testnet/peggo.mdx
+++ b/.gitbook/ko/infra/validator-testnet/peggo.mdx
@@ -23,7 +23,7 @@ cd ~/.peggo
 
 `PEGGO_COSMOS_FROM`을 검증자 키 이름으로, `PEGGO_COSMOS_FROM_PASSPHRASE`를 Cosmos Keyring 비밀번호로 업데이트합니다.
 
-Keyring 설정에 대해 [여기](https://docs.cosmos.network/v0.46/run-node/keyring.html)에서 자세히 알아보세요.
+Keyring 설정에 대해 [여기](https://docs.cosmos.network/sdk/latest/node/keyring)에서 자세히 알아보세요.
 
 ### **2. Cosmos Private Key (안전하지 않음)**
 

--- a/.gitbook/ko/references.mdx
+++ b/.gitbook/ko/references.mdx
@@ -22,7 +22,7 @@ Injective에서 빌드하기 위한 개발자 도구 및 리소스
 | [Injective TypeScript SDK](https://github.com/InjectiveLabs/injective-ts)                                 | TypeScript를 사용하여 Injective에서 dApp 빌드                                                                                   |
 | [Injective API Reference](https://api.injective.exchange)                                     | 트레이더를 위한 Injective와 상호작용하기 위한 상세 API 문서                                                       |
 | [Cosmovisor](./infra/cosmovisor/)                                                 | 거버넌스 모듈을 모니터링하는 Cosmos SDK 바이너리 주변의 소규모 프로세스 관리자                                        |
-| [CosmosSDK](https://docs.cosmos.network/main/build)                                          | Injective 생태계와 통합하는 개발자를 위한 귀중한 리소스 역할을 하는 Cosmos SDK 문서         |
+| [CosmosSDK](https://docs.cosmos.network/sdk/latest/learn)                                          | Injective 생태계와 통합하는 개발자를 위한 귀중한 리소스 역할을 하는 Cosmos SDK 문서         |
 
 ### 생태계 도구 및 리소스
 

--- a/.gitbook/references.mdx
+++ b/.gitbook/references.mdx
@@ -22,7 +22,7 @@ Developer tools and resources to get you building on Injective
 | [Injective TypeScript SDK](https://github.com/InjectiveLabs/injective-ts)                                 | Build dApps on Injective using TypeScript                                                                                   |
 | [Injective API Reference](https://api.injective.exchange)                                     | Detailed API documentation for interacting with Injective for traders                                                       |
 | [Cosmovisor](./infra/cosmovisor/)                                                 | Small process manager around Cosmos SDK binaries that monitors the governance module                                        |
-| [CosmosSDK](https://docs.cosmos.network/main/build)                                          | The Cosmos SDK documentation serving as a valuable resource for developers integrating with the Injective ecosystem         |
+| [CosmosSDK](https://docs.cosmos.network/sdk/latest/learn)                                          | The Cosmos SDK documentation serving as a valuable resource for developers integrating with the Injective ecosystem         |
 
 ### Ecosystem Tools and Resources
 


### PR DESCRIPTION
## Problem

32 distinct external documentation URLs referenced from these docs are dead (HTTP 404). They appear **104 times across 47 files**, in all four language trees (root, `cn`, `jp`, `ko`).

Three separate causes:

1. **`docs.cosmos.network` retired the `/main/`, `/master/` and old versioned `.html` trees** — 28 URLs.
2. **Tendermint's docs were superseded by CometBFT** — the v0.35 `spec/abci/apps.html` page no longer exists anywhere — 1 URL.
3. **`x/circuit` was extracted from the cosmos-sdk monorepo after v0.50**, so `blob/main/proto/cosmos/circuit/v1/tx.proto` now 404s — 3 URLs.

## What I verified

- Each of the 32 URLs was requested with a browser user-agent, following redirects: **all 404**.
- Each replacement returns **200 and a topic-matching page title** — e.g. `x/bank`, `Setting up the keyring`, `ADR 036: Arbitrary Message Signature Specification`. Status codes alone were not treated as sufficient.
- **Soft-404 control test:** deliberately bogus paths such as `/sdk/latest/totally-made-up-abcxyz` return a real 404 on that host, so a 200 here means the page genuinely exists rather than an SPA fallback.
- **Every anchor was checked against the target page's HTML** — all nine anchored replacements contain the referenced `id` (`#antehandlers`, `#message-routing`, `#step-1-antehandler`, `#3-add-genesis-accounts`, `#the-transaction-execution-pipeline`, `#broadcasting-a-transaction`, `#parameters`).
- **Links that merely look stale were deliberately left alone** because they still resolve: `docs.tendermint.com/master/introduction/what-is-tendermint.html#intro-to-abci` (6 occurrences), `docs.tendermint.com/v0.34/tendermint-core/configuration.html` (4), the bare `docs.cosmos.network/` and `docs.tendermint.com/` links, and 107 of the 110 `cosmos-sdk/blob/...` links.

## The proto citations needed more than a tag swap

The three `tx.proto` references used line ranges from an older layout of that file: `#L25-L75`, `#L77-L93`, `#L95-109`. In **every** tag that still carries the file it is only **83 lines long**, so two of those ranges point past the end of the file — the reference would render but highlight nothing.

I re-derived each range from the current file so that every citation highlights exactly the message its heading names:

| heading in this doc | reference |
|---|---|
| `MsgAuthorizeCircuitBreaker` | `#L25-L40` (doc comment + message) |
| `MsgTripCircuitBreaker` | `#L47-L60` |
| `MsgResetCircuitBreaker` | `#L67-L78` |

I pinned the tag **`x/circuit/v0.1.0`**, which this same file already uses for its `x/circuit/ante/circuit.go` reference, rather than introducing a different pin. (As a side effect this also fixes `#L95-109`, which was missing the second `L`.)

## Choosing replacement paths

Where a retired page has a current equivalent I used `/sdk/latest/...`, **resolved and confirmed one path at a time**. `/sdk/latest/` was reorganised relative to the old `/main/` tree, so a single prefix rewrite does not work — for example `/main/basics/accounts` becomes `/sdk/latest/learn/concepts/accounts`, while `/main/modules/bank` becomes `/sdk/latest/modules/bank/README`.

## Scope

URL text only. Every one of the 76 changed lines differs from the original **in the URL alone** — no prose, formatting or frontmatter was touched. (104 replacements land on 76 lines because some lines carry several links, such as the module list in `inj-coin.mdx`.)

All four language trees are updated in the same change so the translations do not drift out of parity — the same reason `docs(cn): sync ...` PRs exist.

## Full mapping

| × | dead URL | replacement |
|---|---|---|
| 13 | `cosmos/v0.46/run-node/keyring.html` | `cosmos/sdk/latest/node/keyring` |
| 12 | `cosmos/main/build` | `cosmos/sdk/latest/learn` |
| 4 | `cosmos/main/basics/accounts` | `cosmos/sdk/latest/learn/concepts/accounts` |
| 4 | `cosmos/main/basics/tx-lifecycle` | `cosmos/sdk/latest/learn/concepts/lifecycle` |
| 4 | `cosmos/main/build/architecture/adr-036-arbitrary-signature` | `cosmos/sdk/latest/reference/architecture/adr-036-arbitrary-signature` |
| 4 | `cosmos/main/build/modules/auth#gas--fees` | `cosmos/sdk/latest/modules/auth/auth#antehandlers` |
| 4 | `cosmos/main/learn/beginner/gas-fees` | `cosmos/sdk/latest/learn/concepts/context-gas-events` |
| 4 | `cosmos/main/modules/auth#parameters` | `cosmos/sdk/latest/modules/auth/auth#parameters` |
| 4 | `cosmos/main/modules/authz` | `cosmos/sdk/latest/modules/authz/README` |
| 4 | `cosmos/main/modules/bank` | `cosmos/sdk/latest/modules/bank/README` |
| 4 | `cosmos/main/modules/crisis` | `cosmos/sdk/latest/modules/crisis/README` |
| 4 | `cosmos/main/modules/distribution` | `cosmos/sdk/latest/modules/distribution/README` |
| 4 | `cosmos/main/modules/gov` | `cosmos/sdk/latest/modules/gov/README` |
| 4 | `cosmos/main/modules/mint` | `cosmos/sdk/latest/modules/mint/README` |
| 4 | `cosmos/main/modules/slashing` | `cosmos/sdk/latest/modules/slashing/README` |
| 4 | `cosmos/main/modules/staking` | `cosmos/sdk/latest/modules/staking/README` |
| 4 | `cosmos/v0.45/modules/auth/03_antehandlers.html` | `cosmos/sdk/latest/modules/auth/auth#antehandlers` |
| 2 | `cosmos/main/learn/advanced/baseapp#antehandler` | `cosmos/sdk/latest/learn/concepts/baseapp#antehandler` |
| 2 | `cosmos/main/learn/advanced/baseapp#msg-service-router` | `cosmos/sdk/latest/learn/concepts/baseapp#message-routing` |
| 2 | `cosmos/main/learn/beginner/tx-lifecycle#antehandler` | `cosmos/sdk/latest/learn/concepts/lifecycle#step-1-antehandler` |
| 2 | `cosmos/main/modules/feegrant` | `cosmos/sdk/latest/modules/feegrant/README` |
| 2 | `cosmos/main/run-node/run-node#adding-genesis-accounts` | `cosmos/sdk/latest/node/run-node#3-add-genesis-accounts` |
| 2 | `cosmos/master/basics/gas-fees.html#antehandler` | `cosmos/sdk/latest/learn/concepts/context-gas-events` |
| 2 | `cosmos/master/core/baseapp.html#runtx` | `cosmos/sdk/latest/learn/concepts/baseapp#the-transaction-execution-pipeline` |
| 2 | `cosmos/master/run-node/txs.html#broadcasting-a-transaction` | `cosmos/sdk/latest/node/txs#broadcasting-a-transaction` |
| 2 | `tendermint/v0.35/spec/abci/apps.html#consensus-connection` | `cosmos/cometbft/latest/spec/abci/Methods` |
| 2 | `sdk-repo/blob/main/proto/cosmos/circuit/v1/tx.proto#L25-L75` | `sdk-repo/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L25-L40` |
| 2 | `sdk-repo/blob/main/proto/cosmos/circuit/v1/tx.proto#L77-L93` | `sdk-repo/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L47-L60` |
| 2 | `sdk-repo/blob/main/proto/cosmos/circuit/v1/tx.proto#L95-109` | `sdk-repo/blob/x/circuit/v0.1.0/proto/cosmos/circuit/v1/tx.proto#L67-L78` |
| 1 | `cosmos/main/learn/advanced/transactions` | `cosmos/sdk/latest/learn/concepts/transactions` |
| 1 | `cosmos/main/modules/auth/vesting/` | `cosmos/sdk/latest/modules/auth/vesting` |
| 1 | `cosmos/v0.50/build/modules/staking` | `cosmos/sdk/latest/modules/staking/README` |
