### PR TITLE
docs(olp): add epoch 64 schedule

### DIFF
--- a/.gitbook/defi/open-liquidity-program/epochs.mdx
+++ b/.gitbook/defi/open-liquidity-program/epochs.mdx
@@ -29,7 +29,5 @@ Start and end dates for OLP epochs are shown in the table below. This table is u
     <tr><td align="center">62</td><td align="right">Aug 4, 2026 00:00:00</td><td align="right">Sep 1, 2026 00:00:00</td><td align="right">20,000</td></tr>
     <tr><td align="center">63</td><td align="right">Sep 1, 2026 00:00:00</td><td align="right">Sep 29, 2026 00:00:00</td><td align="right">20,000</td></tr>
     <tr><td align="center">64</td><td align="right">Sep 29, 2026 00:00:00</td><td align="right">Oct 27, 2026 00:00:00</td><td align="right">15,000</td></tr>
-    <tr><td align="center">65</td><td align="right">Oct 27, 2026 00:00:00</td><td align="right">Nov 24, 2026 00:00:00</td><td align="right">15,000</td></tr>
-    <tr><td align="center">66</td><td align="right">Nov 24, 2026 00:00:00</td><td align="right">Dec 22, 2026 00:00:00</td><td align="right">15,000</td></tr>
   </tbody>
 </table>

--- a/.gitbook/defi/open-liquidity-program/epochs.mdx
+++ b/.gitbook/defi/open-liquidity-program/epochs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Epochs"
 description: "OLP Epoch Duration and Schedule"
-updatedAt: "2026-06-25"
+updatedAt: "2026-08-27"
 ---
 
 An epoch is the period of time in which market makers are evaluated based on their relative performance. Several metrics are cumulatively tracked during each epoch and reset upon the commencement of a new epoch. Rewards are disbursed after the completion of each epoch (see [Rewards Disbursement](/defi/open-liquidity-program/reward-disbursements)). Currently, **each epoch is 28 days long**.
@@ -28,5 +28,8 @@ Start and end dates for OLP epochs are shown in the table below. This table is u
     <tr><td align="center">61</td><td align="right">Jul 7, 2026 00:00:00</td><td align="right">Aug 4, 2026 00:00:00</td><td align="right">25,000</td></tr>
     <tr><td align="center">62</td><td align="right">Aug 4, 2026 00:00:00</td><td align="right">Sep 1, 2026 00:00:00</td><td align="right">20,000</td></tr>
     <tr><td align="center">63</td><td align="right">Sep 1, 2026 00:00:00</td><td align="right">Sep 29, 2026 00:00:00</td><td align="right">20,000</td></tr>
+    <tr><td align="center">64</td><td align="right">Sep 29, 2026 00:00:00</td><td align="right">Oct 27, 2026 00:00:00</td><td align="right">15,000</td></tr>
+    <tr><td align="center">65</td><td align="right">Oct 27, 2026 00:00:00</td><td align="right">Nov 24, 2026 00:00:00</td><td align="right">15,000</td></tr>
+    <tr><td align="center">66</td><td align="right">Nov 24, 2026 00:00:00</td><td align="right">Dec 22, 2026 00:00:00</td><td align="right">15,000</td></tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- Add OLP epoch 64 to the published schedule
- Document its 15,000 INJ reward
- Follow the existing 28-day schedule and exclusive end-date convention
- Leave later epochs unpublished while their rewards remain subject to change
- Update the page timestamp

Related config PR: https://github.com/InjectiveLabs/injective-product-helm/pull/278

## Validation
- Verified epoch 64 spans exactly 28 days
- Verified the Sep 29, 2026 start and 15,000 INJ reward against the Helm config
- Verified the displayed Oct 27, 2026 end follows the existing docs convention
- Verified epochs 65 and 66 are absent
- `git diff --check`